### PR TITLE
Update fulfillmentInboundV0.json

### DIFF
--- a/models/fulfillment-inbound-api-model/fulfillmentInboundV0.json
+++ b/models/fulfillment-inbound-api-model/fulfillmentInboundV0.json
@@ -2882,7 +2882,19 @@
             "required": false,
             "type": "array",
             "items": {
-              "$ref": "#/definitions/ShipmentStatus"
+              "type":"string",
+              "enum": [
+                "WORKING",
+                "SHIPPED",
+                "RECEIVING",
+                "CANCELLED",
+                "DELETED",
+                "CLOSED",
+                "ERROR",
+                "IN_TRANSIT",
+                "DELIVERED",
+                "CHECKED_IN"
+              ]
             }
           },
           {
@@ -4004,7 +4016,7 @@
       "description":"The request schema for an inbound shipment.",
       "type": "object",
       "required": [
-        "MarkeplaceId",
+        "MarketplaceId",
         "InboundShipmentHeader",
         "InboundShipmentItems"
       ],
@@ -5463,7 +5475,7 @@
         }
       ]
     },
-    "ShipmentStatus": {
+     "ShipmentStatus": {
       "description": "Indicates the status of the inbound shipment. When used with the createInboundShipment operation, WORKING is the only valid value. When used with the updateInboundShipment operation, possible values are WORKING, SHIPPED or CANCELLED.",
       "type": "string",
       "enum": [


### PR DESCRIPTION
fixed a typo
swagger 2.0 was not supporting $ref enum reference in query parameter of array type

*Issue #, if available:*4

*Description of changes:* fixed Markeplace typo to  Marketplace in InboundShipmentRequest in required array
 /fba/inbound/v0/shipments/get parameter ShipmentStatusList update to comply for generating client with 2.0 specification


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
