### PR TITLE
Update regex to use Perl's /pattern/modifiers convention

### DIFF
--- a/models/merchant-fulfillment-api-model/merchantFulfillmentV0.json
+++ b/models/merchant-fulfillment-api-model/merchantFulfillmentV0.json
@@ -678,7 +678,7 @@
             "description": "The Amazon-defined shipment identifier for the shipment.",
             "required": true,
             "type": "string",
-            "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+            "pattern": "/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/"
           }
         ],
         "responses": {
@@ -908,7 +908,7 @@
             "description": "The Amazon-defined shipment identifier for the shipment to cancel.",
             "required": true,
             "type": "string",
-            "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+            "pattern": "/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/"
           }
         ],
         "responses": {
@@ -1138,7 +1138,7 @@
             "description": "The Amazon-defined shipment identifier for the shipment to cancel.",
             "required": true,
             "type": "string",
-            "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+            "pattern": "/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/"
           }
         ],
         "responses": {
@@ -2391,7 +2391,7 @@
     "AmazonOrderId": {
       "description": "An Amazon-defined order identifier, in 3-7-7 format.",
       "type": "string",
-      "pattern" : "[0-9A-Z]{3}-[0-9]{7}-[0-9]{7}"
+      "pattern": "/[0-9A-Z]{3}-[0-9]{7}-[0-9]{7}/"
     },
     "CancelShipmentResponse": {
       "description": "Response schema.",

--- a/models/notifications-api-model/notifications.json
+++ b/models/notifications-api-model/notifications.json
@@ -183,7 +183,7 @@
           "description":"The Amazon Resource Name (ARN) associated with the SQS queue.",
           "type":"string",
           "maxLength": 1000,
-          "pattern": "^arn:aws:sqs:\\S+:\\S+:\\S+"
+          "pattern": "/^arn:aws:sqs:\\S+:\\S+:\\S+/"
         }
       }
     },

--- a/models/sales-api-model/sales.json
+++ b/models/sales-api-model/sales.json
@@ -161,7 +161,7 @@
     },
     "Decimal":
     {
-      "pattern": "^-?(0|([1-9]\\d*))(\\.\\d+)?([eE][+-]?\\d+)?$",
+      "pattern": "/^-?(0|([1-9]\\d*))(\\.\\d+)?([eE][+-]?\\d+)?$/",
       "description": "A decimal number with no loss of precision. Useful when precision loss is unnaceptable, as with currencies. Follows RFC7159 for number representation.",
       "type": "string"
     }

--- a/models/sellers-api-model/sellers.json
+++ b/models/sellers-api-model/sellers.json
@@ -102,7 +102,7 @@
           "type": "string"
         },
         "countryCode": {
-          "pattern": "^([A-Z]{2})$",
+          "pattern": "/^([A-Z]{2})$/",
           "description": "The ISO 3166-1 alpha-2 format country code of the marketplace.",
           "type": "string"
         },

--- a/models/services-api-model/services.json
+++ b/models/services-api-model/services.json
@@ -204,7 +204,7 @@
         "marketplaceId": {
           "description": "The marketplace identifier.",
           "type": "string",
-          "pattern": "^[A-Z0-9]*$"
+          "pattern": "/^[A-Z0-9]*$/"
         },
         "buyer": {
           "description": "Information about the buyer.",
@@ -267,7 +267,7 @@
         "sellerId": {
           "description": "The identifier of the seller of the service job.",
           "type": "string",
-          "pattern": "^[A-Z0-9]*$"
+          "pattern": "/^[A-Z0-9]*$/"
         }
       }
     },
@@ -278,7 +278,7 @@
         "serviceJobProviderId": {
           "description": "The identifier of the service job provider",
           "type": "string",
-          "pattern": "^[A-Z0-9]*$"
+          "pattern": "/^[A-Z0-9]*$/"
         }
       }
     },
@@ -289,7 +289,7 @@
         "buyerId": {
           "description": "The identifier of the buyer.",
           "type": "string",
-          "pattern": "^[A-Z0-9]*$"
+          "pattern": "/^[A-Z0-9]*$/"
         },
         "name": {
           "description": "The name of the buyer.",
@@ -419,7 +419,7 @@
         "uploadingTechnician": {
           "description": "The identifier of the technician who uploaded the POA.",
           "type": "string",
-          "pattern": "^[A-Z0-9]*$"
+          "pattern": "/^[A-Z0-9]*$/"
         },
         "uploadTime": {
           "description": "The date and time when the POA was uploaded, in ISO 8601 format.",
@@ -1241,7 +1241,7 @@
             "in": "query",
             "required": true,
             "type": "string",
-            "pattern": "^[A-Z0-9_]*$",
+            "pattern": "/^[A-Z0-9_]*$/",
             "minLength": 1,
             "maxLength": 100
           }


### PR DESCRIPTION
*Problem:*  
The patterns defined in the json models does not respect the Perl's */`pattern`/`modifiers`* convention which caused an exception to occur while generating the code in C# with SwaggerCodegen.
  
*Description of changes:*
Updated all the regex patterns to use the Perl's */`pattern`/`modifiers`* to enable the templates to be generated in C#.
* Note that the 'modifiers' part is not mandatory nor given.
* Also, **this is not a problem with java** in SwaggerCodegen since it use the default pattern processing implementation which add the `/` `/`delimiters automatically if they are not present.
  
*Fix this error:*
[main] INFO io.swagger.codegen.languages.CSharpClientCodegen - Generating code for .NET Framework v4.5
[main] ERROR io.swagger.codegen.DefaultGenerator - Could not process model 'GetAdditionalSellerInputsRequest'. Please make sure that your schema is correct!
java.lang.IllegalArgumentException: Pattern must follow the Perl /pattern/modifiers convention. [0-9A-Z]{3}-[0-9]{7}-[0-9]{7} is not valid.
  at io.swagger.codegen.languages.CSharpClientCodegen.postProcessPattern(CSharpClientCodegen.java:619)