### PR TITLE
add endpoint tags to the Finances API spec

### DIFF
--- a/models/finances-api-model/financesV0.json
+++ b/models/finances-api-model/financesV0.json
@@ -26,6 +26,9 @@
   "paths": {
     "/finances/v0/financialEventGroups": {
       "get": {
+        "tags": [
+          "finances"
+        ],
         "description": "Returns financial event groups for a given date range.\n\n**Usage Plan:**\n\n| Rate (requests per second) | Burst |\n| ---- | ---- |\n| 0.5 | 30 |\n\nFor more information, see \"Usage Plans and Rate Limits\" in the Selling Partner API documentation.",
         "operationId": "listFinancialEventGroups",
         "parameters": [
@@ -208,6 +211,9 @@
     },
     "/finances/v0/financialEventGroups/{eventGroupId}/financialEvents": {
       "get": {
+        "tags": [
+          "finances"
+        ],
         "description": "Returns all financial events for the specified financial event group.\n\n**Usage Plan:**\n\n| Rate (requests per second) | Burst |\n| ---- | ---- |\n| 0.5 | 30 |\n\nFor more information, see \"Usage Plans and Rate Limits\" in the Selling Partner API documentation.",
         "operationId": "listFinancialEventsByGroupId",
         "parameters": [
@@ -661,6 +667,9 @@
     },
     "/finances/v0/orders/{orderId}/financialEvents": {
       "get": {
+        "tags": [
+          "finances"
+        ],
         "description": "Returns all financial events for the specified order.\n\n**Usage Plan:**\n\n| Rate (requests per second) | Burst |\n| ---- | ---- |\n| 0.5 | 30 |\n\nFor more information, see \"Usage Plans and Rate Limits\" in the Selling Partner API documentation.",
         "operationId": "listFinancialEventsByOrderId",
         "parameters": [
@@ -926,6 +935,9 @@
     },
     "/finances/v0/financialEvents": {
       "get": {
+        "tags": [
+          "finances"
+        ],
         "description": "Returns financial events for the specified data range.\n\n**Usage Plan:**\n\n| Rate (requests per second) | Burst |\n| ---- | ---- |\n| 0.5 | 30 |\n\nFor more information, see \"Usage Plans and Rate Limits\" in the Selling Partner API documentation.",
         "operationId": "listFinancialEvents",
         "parameters": [


### PR DESCRIPTION
Fixes #20

Problem summary: endpoint tags are missing for the Finances spec, which causes code generators to generate files and objects with default names instead of the appropriate name

Fix: added endpoint tags to the finances JSON