### PR TITLE
currency amount should not be formatted as a floating point number

### DIFF
--- a/models/merchant-fulfillment-api-model/merchantFulfillmentV0.json
+++ b/models/merchant-fulfillment-api-model/merchantFulfillmentV0.json
@@ -2048,9 +2048,8 @@
           "maxLength": 3
         },
         "Amount": {
-          "type": "number",
-          "format": "double",
-          "description": "The currency amount."
+          "description": "The currency amount.",
+          "type": "number"
         }
       },
       "description": "Currency type and amount."


### PR DESCRIPTION
By setting the "format" to "double" in the CurrencyAmount Amount field code generation is being directed towards a floating point type (see https://swagger.io/docs/specification/data-models/data-types/#numbers).  Since currency amounts should not be stored in a floating point type to avoid rounding issues, the format field should not be set here.

When using the OpenApi "java" generator, the CurrencyAmount class generated had the amount type Double; after removing the "format" specifier the type used became BigDecimal - which is the appropriate type for currency values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
