### PR TITLE
Fixed issue with generated C# client library API calls not properly replacing parameters in the query string

### DIFF
--- a/clients/sellingpartner-api-aa-csharp/src/Amazon.SellingPartnerAPIAA/resources/swagger-codegen/templates/api.mustache
+++ b/clients/sellingpartner-api-aa-csharp/src/Amazon.SellingPartnerAPIAA/resources/swagger-codegen/templates/api.mustache
@@ -187,7 +187,7 @@ namespace {{packageName}}.{{apiPackage}}
             {{/required}}
             {{/allParams}}
 
-            var localVarPath = "{{#netStandard}}.{{/netStandard}}{{{path}}}";
+            var localVarPath = $"{{#netStandard}}.{{/netStandard}}{{{path}}}";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new List<KeyValuePair<String, String>>();
             var localVarHeaderParams = new Dictionary<String, String>(this.Configuration.DefaultHeader);
@@ -323,7 +323,7 @@ namespace {{packageName}}.{{apiPackage}}
             {{/required}}
             {{/allParams}}
 
-            var localVarPath = "{{#netStandard}}.{{/netStandard}}{{{path}}}";
+            var localVarPath = $"{{#netStandard}}.{{/netStandard}}{{{path}}}";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new List<KeyValuePair<String, String>>();
             var localVarHeaderParams = new Dictionary<String, String>(this.Configuration.DefaultHeader);

--- a/clients/sellingpartner-api-aa-csharp/test/Amazon.SellingPartnerAPIAATests/AWSSignerHelperTest.cs
+++ b/clients/sellingpartner-api-aa-csharp/test/Amazon.SellingPartnerAPIAATests/AWSSignerHelperTest.cs
@@ -156,8 +156,8 @@ namespace Amazon.SellingPartnerAPIAATests
         {
             string expectedCanonicalHash = "foo";
             StringBuilder expectedStringBuilder = new StringBuilder();
-            expectedStringBuilder.AppendLine("AWS4-HMAC-SHA256");
-            expectedStringBuilder.AppendLine(ISOSigningDateTime);
+            expectedStringBuilder.Append("AWS4-HMAC-SHA256\n");
+            expectedStringBuilder.Append(ISOSigningDateTime + "\n");
             expectedStringBuilder.AppendFormat("{0}/{1}/execute-api/aws4_request\n", ISOSigningDate, TestRegion);
             expectedStringBuilder.Append(expectedCanonicalHash);
 

--- a/models/product-fees-api-model/productFeesV0.json
+++ b/models/product-fees-api-model/productFeesV0.json
@@ -24,7 +24,7 @@
     "application/json"
   ],
   "paths": {
-    "/products/fees/v0/listings/{SellerSKU}/feesEstimate": {
+    "/products/fees/v0/listings/{sellerSKU}/feesEstimate": {
       "post": {
         "tags": [
           "fees"
@@ -277,7 +277,7 @@
       },
       "parameters": []
     },
-    "/products/fees/v0/items/{Asin}/feesEstimate": {
+    "/products/fees/v0/items/{asin}/feesEstimate": {
       "post": {
         "tags": [
           "fees"

--- a/models/product-pricing-api-model/productPricingV0.json
+++ b/models/product-pricing-api-model/productPricingV0.json
@@ -1319,7 +1319,7 @@
         }
       }
     },
-    "/products/pricing/v0/listings/{SellerSKU}/offers": {
+    "/products/pricing/v0/listings/{sellerSKU}/offers": {
       "get": {
         "tags": [
           "productPricing"
@@ -1586,7 +1586,7 @@
         }
       }
     },
-    "/products/pricing/v0/items/{Asin}/offers": {
+    "/products/pricing/v0/items/{asin}/offers": {
       "get": {
         "tags": [
           "productPricing"


### PR DESCRIPTION
When generating a C# client library, we were getting a signature calculation error on any calls that include parameters on the query string like this one: 

GET https://sellingpartnerapi-na.amazon.com/orders/v0/orders/xxxxxxxxx/address

Because the $ character was omitted in the api.mustache file, the localVarPath was not calculated correctly. The bug manifested itself as a signature calculation issue, but clearly the call would not have succeeded even if the signature had calculated correctly.

Once this fix was made, a few other bugs in the json models became apparent due to some camel-casing issues.  These were also fixed.

Finally we fixed a failing unit test that was caused by Windows line-feeds versus Unix line-feeds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
