### PR TITLE
Fix catalogItems_2020-12-01.json

### DIFF
--- a/models/catalog-items-api-model/catalogItems_2020-12-01.json
+++ b/models/catalog-items-api-model/catalogItems_2020-12-01.json
@@ -112,7 +112,7 @@
             },
             "collectionFormat": "csv",
             "x-example": "summaries",
-            "default": "summaries"
+            "default": ["summaries"]
           }
         ],
         "responses": {


### PR DESCRIPTION
The default value for `includedData` parameter was a `string` instead of an `array`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
