### PR TITLE
Fix merchantFulfillmentV0.json

### DIFF
--- a/models/merchant-fulfillment-api-model/merchantFulfillmentV0.json
+++ b/models/merchant-fulfillment-api-model/merchantFulfillmentV0.json
@@ -37,7 +37,6 @@
             "name": "body",
             "required": true,
             "schema": {
-              "description": "Request schema.",
               "$ref": "#/definitions/GetEligibleShipmentServicesRequest"
             }
           }
@@ -379,7 +378,6 @@
             "name": "body",
             "required": true,
             "schema": {
-              "description": "Request schema.",
               "$ref": "#/definitions/GetEligibleShipmentServicesRequest"
             }
           }


### PR DESCRIPTION
When generating TS client with the [Openapi generator](https://openapi-generator.tech/) with [merchantFulfillmentV0.json](https://github.com/amzn/selling-partner-api-models/blob/main/models/merchant-fulfillment-api-model/merchantFulfillmentV0.json)

This error occurred :

```
Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 2, Warning count: 1
Errors: 
        -attribute paths.'/mfn/v0/eligibleShippingServices'(post).[body].description is unexpected
        -attribute paths.'/mfn/v0/eligibleServices'(post).[body].description is unexpected
Warnings: 
        -attribute paths.'/mfn/v0/eligibleShippingServices'(post).[body].description is unexpected
        -attribute paths.'/mfn/v0/eligibleServices'(post).[body].description is unexpected

        at org.openapitools.codegen.config.CodegenConfigurator.toContext(CodegenConfigurator.java:546)
        at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:573)
        at org.openapitools.codegen.cmd.Generate.execute(Generate.java:432)
        at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
        at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
```

Sibling values alongside  $refs are ignored.

And the description for the schema is already given during its definition :

https://github.com/My42/selling-partner-api-models/blob/9be85d26ce553c9189cadec46ea4599a9fb91ccf/models/merchant-fulfillment-api-model/merchantFulfillmentV0.json#L2812

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
