### PR TITLE
Fix shipping.json

### DIFF
--- a/models/shipping-api-model/shipping.json
+++ b/models/shipping-api-model/shipping.json
@@ -711,7 +711,64 @@
         "shipFrom",
         "shipTo"
       ],
-      "type": "object"
+      "type": "object",
+      "example": {
+        "clientReferenceId": "911-7267646-6348616",
+        "shipFrom": {
+          "name": "test name 1",
+          "addressLine1": "some Test address 1",
+          "postalCode": "90013",
+          "city": "Los Angeles",
+          "countryCode": "US",
+          "stateOrRegion": "CA",
+          "email": "testEmail1@amazon.com",
+          "phoneNumber": "1234567890"
+        },
+        "shipTo": {
+          "name": "test name 2",
+          "addressLine1": "some Test address 2",
+          "postalCode": "90013-1805",
+          "city": "LOS ANGELES",
+          "countryCode": "US",
+          "stateOrRegion": "CA",
+          "email": "testEmail2@amazon.com",
+          "phoneNumber": "1234567890"
+        },
+        "containers": [
+          {
+            "containerType": "PACKAGE",
+            "containerReferenceId": "ContainerRefId-01",
+            "items": [
+              {
+                "title": "String",
+                "quantity": 2,
+                "unitPrice": {
+                  "unit": "USD",
+                  "value": 14.99
+                },
+                "unitWeight": {
+                  "unit": "lb",
+                  "value": 0.08164656
+                }
+              }
+            ],
+            "dimensions": {
+              "height": 12,
+              "length": 36,
+              "width": 15,
+              "unit": "CM"
+            },
+            "weight": {
+              "unit": "lb",
+              "value": 0.08164656
+            },
+            "value": {
+              "unit": "USD",
+              "value": 29.98
+            }
+          }
+        ]
+      }
     },
     "PurchaseLabelsRequest": {
       "description": "The request schema for the purchaseLabels operation.",
@@ -727,7 +784,14 @@
         "labelSpecification",
         "rateId"
       ],
-      "type": "object"
+      "type": "object",
+      "example": {
+        "rateId": "rate identifier",
+        "labelSpecification": {
+          "labelFormat": "PNG",
+          "labelStockSize": "4x6"
+        }
+      }
     },
     "RetrieveShippingLabelRequest": {
       "description": "The request schema for the retrieveShippingLabel operation.",
@@ -739,7 +803,13 @@
       "required": [
         "labelSpecification"
       ],
-      "type": "object"
+      "type": "object",
+      "example": {
+        "labelSpecification": {
+          "labelFormat": "PNG",
+          "labelStockSize": "4x6"
+        }
+      }
     },
     "GetRatesRequest": {
       "description": "The payload schema for the getRates operation.",
@@ -768,7 +838,42 @@
         "shipFrom",
         "shipTo"
       ],
-      "type": "object"
+      "type": "object",
+      "example": {
+        "shipFrom": {
+          "name": "test name 1",
+          "addressLine1": "some Test address 1",
+          "postalCode": "90013",
+          "city": "Los Angeles",
+          "countryCode": "US",
+          "stateOrRegion": "CA"
+        },
+        "shipTo": {
+          "name": "test name 2",
+          "addressLine1": "some Test address 2",
+          "postalCode": "90013",
+          "city": "Los Angeles",
+          "countryCode": "US",
+          "stateOrRegion": "CA"
+        },
+        "containerSpecifications": [
+          {
+            "dimensions": {
+              "height": 12,
+              "length": 36,
+              "width": 15,
+              "unit": "CM"
+            },
+            "weight": {
+              "unit": "lb",
+              "value": 0.08164656
+            }
+          }
+        ],
+        "serviceTypes": [
+          "Amazon Shipping Standard"
+        ]
+      }
     },
     "PurchaseShipmentRequest": {
       "description": "The payload schema for the purchaseShipment operation.",
@@ -805,7 +910,69 @@
         "shipFrom",
         "shipTo"
       ],
-      "type": "object"
+      "type": "object",
+      "example": {
+        "clientReferenceId": "911-7267646-6348616",
+        "shipFrom": {
+          "name": "test name 1",
+          "addressLine1": "some Test address 1",
+          "postalCode": "90013",
+          "city": "Los Angeles",
+          "countryCode": "US",
+          "stateOrRegion": "CA",
+          "email": "testEmail1@amazon.com",
+          "phoneNumber": "1234567890"
+        },
+        "shipTo": {
+          "name": "test name 2",
+          "addressLine1": "some Test address 2",
+          "postalCode": "90013",
+          "city": "Los Angeles",
+          "countryCode": "US",
+          "stateOrRegion": "CA",
+          "email": "testEmail2@amazon.com",
+          "phoneNumber": "1234567890"
+        },
+        "containers": [
+          {
+            "containerType": "PACKAGE",
+            "containerReferenceId": "ContainerRefId-01",
+            "items": [
+              {
+                "title": "String",
+                "quantity": 2,
+                "unitPrice": {
+                  "unit": "USD",
+                  "value": 14.99
+                },
+                "unitWeight": {
+                  "unit": "lb",
+                  "value": 0.08164656
+                }
+              }
+            ],
+            "dimensions": {
+              "height": 12,
+              "length": 36,
+              "width": 15,
+              "unit": "CM"
+            },
+            "weight": {
+              "unit": "lb",
+              "value": 0.08164656
+            },
+            "value": {
+              "unit": "USD",
+              "value": 29.98
+            }
+          }
+        ],
+        "labelSpecification": {
+          "labelFormat": "PNG",
+          "labelStockSize": "4x6"
+        },
+        "serviceType": "Amazon Shipping Standard"
+      }
     },
     "CreateShipmentResult": {
       "description": "The payload schema for the createShipment operation.",
@@ -1412,63 +1579,6 @@
           "in": "body",
           "name": "body",
           "schema": {
-            "example": {
-              "clientReferenceId": "911-7267646-6348616",
-              "shipFrom": {
-                "name": "test name 1",
-                "addressLine1": "some Test address 1",
-                "postalCode": "90013",
-                "city": "Los Angeles",
-                "countryCode": "US",
-                "stateOrRegion": "CA",
-                "email": "testEmail1@amazon.com",
-                "phoneNumber": "1234567890"
-              },
-              "shipTo": {
-                "name": "test name 2",
-                "addressLine1": "some Test address 2",
-                "postalCode": "90013-1805",
-                "city": "LOS ANGELES",
-                "countryCode": "US",
-                "stateOrRegion": "CA",
-                "email": "testEmail2@amazon.com",
-                "phoneNumber": "1234567890"
-              },
-              "containers": [
-                {
-                  "containerType": "PACKAGE",
-                  "containerReferenceId": "ContainerRefId-01",
-                  "items": [
-                    {
-                      "title": "String",
-                      "quantity": 2,
-                      "unitPrice": {
-                        "unit": "USD",
-                        "value": 14.99
-                      },
-                      "unitWeight": {
-                        "unit": "lb",
-                        "value": 0.08164656
-                      }
-                    }
-                  ],
-                  "dimensions": {
-                    "height": 12,
-                    "length": 36,
-                    "width": 15,
-                    "unit": "CM"
-                  },
-                  "weight": {
-                    "unit": "lb",
-                    "value": 0.08164656
-                  },
-                  "value": {
-                    "unit": "USD",
-                    "value": 29.98
-                  }
-                }
-              ]
-            },
             "$ref": "#/definitions/CreateShipmentRequest"
           }
         }]
@@ -2457,13 +2567,6 @@
           "in": "body",
           "name": "body",
           "schema": {
-            "example": {
-              "rateId": "rate identifier",
-              "labelSpecification": {
-                "labelFormat": "PNG",
-                "labelStockSize": "4x6"
-              }
-            },
             "$ref": "#/definitions/PurchaseLabelsRequest"
           }
         }]
@@ -2751,12 +2854,6 @@
           "in": "body",
           "name": "body",
           "schema": {
-            "example": {
-              "labelSpecification": {
-                "labelFormat": "PNG",
-                "labelStockSize": "4x6"
-              }
-            },
             "$ref": "#/definitions/RetrieveShippingLabelRequest"
           }
         }]
@@ -2964,68 +3061,6 @@
             "in": "body",
             "name": "body",
             "schema": {
-              "example": {
-                "clientReferenceId": "911-7267646-6348616",
-                "shipFrom": {
-                  "name": "test name 1",
-                  "addressLine1": "some Test address 1",
-                  "postalCode": "90013",
-                  "city": "Los Angeles",
-                  "countryCode": "US",
-                  "stateOrRegion": "CA",
-                  "email": "testEmail1@amazon.com",
-                  "phoneNumber": "1234567890"
-                },
-                "shipTo": {
-                  "name": "test name 2",
-                  "addressLine1": "some Test address 2",
-                  "postalCode": "90013",
-                  "city": "Los Angeles",
-                  "countryCode": "US",
-                  "stateOrRegion": "CA",
-                  "email": "testEmail2@amazon.com",
-                  "phoneNumber": "1234567890"
-                },
-                "containers": [
-                  {
-                    "containerType": "PACKAGE",
-                    "containerReferenceId": "ContainerRefId-01",
-                    "items": [
-                      {
-                        "title": "String",
-                        "quantity": 2,
-                        "unitPrice": {
-                          "unit": "USD",
-                          "value": 14.99
-                        },
-                        "unitWeight": {
-                          "unit": "lb",
-                          "value": 0.08164656
-                        }
-                      }
-                    ],
-                    "dimensions": {
-                      "height": 12,
-                      "length": 36,
-                      "width": 15,
-                      "unit": "CM"
-                    },
-                    "weight": {
-                      "unit": "lb",
-                      "value": 0.08164656
-                    },
-                    "value": {
-                      "unit": "USD",
-                      "value": 29.98
-                    }
-                  }
-                ],
-                "labelSpecification": {
-                  "labelFormat": "PNG",
-                  "labelStockSize": "4x6"
-                },
-                "serviceType": "Amazon Shipping Standard"
-              },
               "$ref": "#/definitions/PurchaseShipmentRequest"
             }
           }
@@ -3204,41 +3239,6 @@
             "in": "body",
             "name": "body",
             "schema": {
-              "example": {
-                "shipFrom": {
-                  "name": "test name 1",
-                  "addressLine1": "some Test address 1",
-                  "postalCode": "90013",
-                  "city": "Los Angeles",
-                  "countryCode": "US",
-                  "stateOrRegion": "CA"
-                },
-                "shipTo": {
-                  "name": "test name 2",
-                  "addressLine1": "some Test address 2",
-                  "postalCode": "90013",
-                  "city": "Los Angeles",
-                  "countryCode": "US",
-                  "stateOrRegion": "CA"
-                },
-                "containerSpecifications": [
-                  {
-                    "dimensions": {
-                      "height": 12,
-                      "length": 36,
-                      "width": 15,
-                      "unit": "CM"
-                    },
-                    "weight": {
-                      "unit": "lb",
-                      "value": 0.08164656
-                    }
-                  }
-                ],
-                "serviceTypes": [
-                  "Amazon Shipping Standard"
-                ]
-              },
               "$ref": "#/definitions/GetRatesRequest"
             }
           }


### PR DESCRIPTION
When generating TS client with the [Openapi generator](https://openapi-generator.tech/) with [shipping.json](https://github.com/amzn/selling-partner-api-models/blob/main/models/shipping-api-model/shipping.json)

This error occurred :

```
Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 5, Warning count: 0
Errors: 
        -attribute paths.'/shipping/v1/shipments'(post).[body].example is unexpected
        -attribute paths.'/shipping/v1/shipments/{shipmentId}/purchaseLabels'(post).[body].example is unexpected
        -attribute paths.'/shipping/v1/rates'(post).[body].example is unexpected
        -attribute paths.'/shipping/v1/purchaseShipment'(post).[body].example is unexpected
        -attribute paths.'/shipping/v1/shipments/{shipmentId}/containers/{trackingId}/label'(post).[body].example is unexpected
        at org.openapitools.codegen.config.CodegenConfigurator.toContext(CodegenConfigurator.java:546)
        at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:573)
        at org.openapitools.codegen.cmd.Generate.execute(Generate.java:432)
        at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
        at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
```

Sibling values alongside  $refs are ignored.

The solution is to use `allOf` or add the `example` property during the definition of the schema

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
