### PR TITLE
Fix vendorInvoices.json

### DIFF
--- a/models/vendor-invoices-api-model/vendorInvoices.json
+++ b/models/vendor-invoices-api-model/vendorInvoices.json
@@ -37,249 +37,7 @@
             "name": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/SubmitInvoicesRequest",
-              "example": {
-                "payload": {
-                  "invoices": [
-                    {
-                      "invoiceType": "Invoice",
-                      "id": "0136981234",
-                      "date": "2019-07-24T21:17:59.821Z",
-                      "remitToParty": {
-                        "partyId": "XYZ12345",
-                        "address": {
-                          "name": "XYZ INDIA PRIVATE LIMITED",
-                          "addressLine1": "4TH FLOOR",
-                          "city": "GURUGRAM",
-                          "stateOrRegion": "HR",
-                          "postalOrZipCode": "122002",
-                          "countryCode": "IN"
-                        },
-                        "taxRegistrationDetails": [
-                          {
-                            "taxRegistrationType": "VAT",
-                            "taxRegistrationNumber": "VENDORVATID"
-                          }
-                        ]
-                      },
-                      "shipToParty": {
-                        "partyId": "AMAZONIN",
-                        "address": {
-                          "name": "AMAZON INDIA",
-                          "addressLine1": "Chowranghee Mansion JN Road",
-                          "city": "Kolkata",
-                          "stateOrRegion": "WB",
-                          "countryCode": "IN"
-                        }
-                      },
-                      "shipFromParty": {
-                        "partyId": "XYZ12345",
-                        "address": {
-                          "name": "XYZ RETAIL PVT LTD",
-                          "addressLine1": "Chowranghee Mansion JN Road",
-                          "city": "Kolkata",
-                          "stateOrRegion": "WB",
-                          "postalOrZipCode": "700016",
-                          "countryCode": "IN"
-                        }
-                      },
-                      "billToParty": {
-                        "partyId": "AMAZONIN",
-                        "address": {
-                          "name": "AMAZON INDIA",
-                          "addressLine1": "Arrjaw Industrial & Warehouse Park",
-                          "addressLine2": "Near Coal India Complex",
-                          "city": "Hooghly",
-                          "stateOrRegion": "WB",
-                          "postalOrZipCode": "712310",
-                          "countryCode": "IN"
-                        },
-                        "taxRegistrationDetails": [
-                          {
-                            "taxRegistrationType": "VAT",
-                            "taxRegistrationNumber": "AMAZONVATID"
-                          }
-                        ]
-                      },
-                      "paymentTerms": {
-                        "type": "Basic",
-                        "discountPercent": "5",
-                        "discountDueDays": 15,
-                        "netDueDays": 30
-                      },
-                      "invoiceTotal": {
-                        "currencyCode": "INR",
-                        "amount": "259678.39"
-                      },
-                      "taxDetails": [
-                        {
-                          "taxType": "SGST",
-                          "taxRate": "9",
-                          "taxAmount": {
-                            "currencyCode": "INR",
-                            "amount": "19697.98"
-                          },
-                          "taxableAmount": {
-                            "currencyCode": "INR",
-                            "amount": "218866.43"
-                          }
-                        },
-                        {
-                          "taxType": "CGST",
-                          "taxRate": "9",
-                          "taxAmount": {
-                            "currencyCode": "INR",
-                            "amount": "19697.98"
-                          },
-                          "taxableAmount": {
-                            "currencyCode": "INR",
-                            "amount": "218866.43"
-                          }
-                        }
-                      ],
-                      "chargeDetails": [
-                        {
-                          "type": "Freight",
-                          "description": "Freight Charges",
-                          "chargeAmount": {
-                            "currencyCode": "INR",
-                            "amount": "1200.00"
-                          },
-                          "taxDetails": [
-                            {
-                              "taxType": "CGST",
-                              "taxRate": "9",
-                              "taxAmount": {
-                                "currencyCode": "INR",
-                                "amount": "108.00"
-                              },
-                              "taxableAmount": {
-                                "currencyCode": "INR",
-                                "amount": "1200.00"
-                              }
-                            },
-                            {
-                              "taxType": "SGST",
-                              "taxRate": "9",
-                              "taxAmount": {
-                                "currencyCode": "INR",
-                                "amount": "108.00"
-                              },
-                              "taxableAmount": {
-                                "currencyCode": "INR",
-                                "amount": "1200.00"
-                              }
-                            }
-                          ]
-                        }
-                      ],
-                      "items": [
-                        {
-                          "itemSequenceNumber": 1,
-                          "amazonProductIdentifier": "ABC123434",
-                          "vendorProductIdentifier": "809281-5100",
-                          "invoicedQuantity": {
-                            "amount": 2,
-                            "unitOfMeasure": "Eaches"
-                          },
-                          "netCost": {
-                            "currencyCode": "INR",
-                            "amount": "21060.34"
-                          },
-                          "purchaseOrderNumber": "3DY3TK6T",
-                          "hsnCode": "76.06.92.99.00",
-                          "taxDetails": [
-                            {
-                              "taxType": "SGST",
-                              "taxRate": "9",
-                              "taxAmount": {
-                                "currencyCode": "INR",
-                                "amount": "1895.43"
-                              },
-                              "taxableAmount": {
-                                "currencyCode": "INR",
-                                "amount": "21060.34"
-                              }
-                            },
-                            {
-                              "taxType": "CGST",
-                              "taxRate": "9",
-                              "taxAmount": {
-                                "currencyCode": "INR",
-                                "amount": "1895.43"
-                              },
-                              "taxableAmount": {
-                                "currencyCode": "INR",
-                                "amount": "21060.34"
-                              }
-                            }
-                          ],
-                          "chargeDetails": [
-                            {
-                              "type": "Freight",
-                              "description": "Freight Charges",
-                              "chargeAmount": {
-                                "currencyCode": "INR",
-                                "amount": "600.00"
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "itemSequenceNumber": 2,
-                          "amazonProductIdentifier": "ABC123435",
-                          "vendorProductIdentifier": "795000-0001",
-                          "invoicedQuantity": {
-                            "amount": 3,
-                            "unitOfMeasure": "Eaches"
-                          },
-                          "netCost": {
-                            "currencyCode": "INR",
-                            "amount": "58915.25"
-                          },
-                          "purchaseOrderNumber": "3DY3TK6T",
-                          "taxDetails": [
-                            {
-                              "taxType": "SGST",
-                              "taxRate": "9",
-                              "taxAmount": {
-                                "currencyCode": "INR",
-                                "amount": "5302.37"
-                              },
-                              "taxableAmount": {
-                                "currencyCode": "INR",
-                                "amount": "58915.25"
-                              }
-                            },
-                            {
-                              "taxType": "CGST",
-                              "taxRate": "9",
-                              "taxAmount": {
-                                "currencyCode": "INR",
-                                "amount": "5302.37"
-                              },
-                              "taxableAmount": {
-                                "currencyCode": "INR",
-                                "amount": "58915.25"
-                              }
-                            }
-                          ],
-                          "chargeDetails": [
-                            {
-                              "type": "Freight",
-                              "description": "Freight Charges",
-                              "chargeAmount": {
-                                "currencyCode": "INR",
-                                "amount": "600.00"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
+              "$ref": "#/definitions/SubmitInvoicesRequest"
             }
           }
         ],
@@ -547,7 +305,249 @@
           }
         }
       },
-      "description": "The request schema for the submitInvoices operation."
+      "description": "The request schema for the submitInvoices operation.",
+      "example": {
+        "payload": {
+          "invoices": [
+            {
+              "invoiceType": "Invoice",
+              "id": "0136981234",
+              "date": "2019-07-24T21:17:59.821Z",
+              "remitToParty": {
+                "partyId": "XYZ12345",
+                "address": {
+                  "name": "XYZ INDIA PRIVATE LIMITED",
+                  "addressLine1": "4TH FLOOR",
+                  "city": "GURUGRAM",
+                  "stateOrRegion": "HR",
+                  "postalOrZipCode": "122002",
+                  "countryCode": "IN"
+                },
+                "taxRegistrationDetails": [
+                  {
+                    "taxRegistrationType": "VAT",
+                    "taxRegistrationNumber": "VENDORVATID"
+                  }
+                ]
+              },
+              "shipToParty": {
+                "partyId": "AMAZONIN",
+                "address": {
+                  "name": "AMAZON INDIA",
+                  "addressLine1": "Chowranghee Mansion JN Road",
+                  "city": "Kolkata",
+                  "stateOrRegion": "WB",
+                  "countryCode": "IN"
+                }
+              },
+              "shipFromParty": {
+                "partyId": "XYZ12345",
+                "address": {
+                  "name": "XYZ RETAIL PVT LTD",
+                  "addressLine1": "Chowranghee Mansion JN Road",
+                  "city": "Kolkata",
+                  "stateOrRegion": "WB",
+                  "postalOrZipCode": "700016",
+                  "countryCode": "IN"
+                }
+              },
+              "billToParty": {
+                "partyId": "AMAZONIN",
+                "address": {
+                  "name": "AMAZON INDIA",
+                  "addressLine1": "Arrjaw Industrial & Warehouse Park",
+                  "addressLine2": "Near Coal India Complex",
+                  "city": "Hooghly",
+                  "stateOrRegion": "WB",
+                  "postalOrZipCode": "712310",
+                  "countryCode": "IN"
+                },
+                "taxRegistrationDetails": [
+                  {
+                    "taxRegistrationType": "VAT",
+                    "taxRegistrationNumber": "AMAZONVATID"
+                  }
+                ]
+              },
+              "paymentTerms": {
+                "type": "Basic",
+                "discountPercent": "5",
+                "discountDueDays": 15,
+                "netDueDays": 30
+              },
+              "invoiceTotal": {
+                "currencyCode": "INR",
+                "amount": "259678.39"
+              },
+              "taxDetails": [
+                {
+                  "taxType": "SGST",
+                  "taxRate": "9",
+                  "taxAmount": {
+                    "currencyCode": "INR",
+                    "amount": "19697.98"
+                  },
+                  "taxableAmount": {
+                    "currencyCode": "INR",
+                    "amount": "218866.43"
+                  }
+                },
+                {
+                  "taxType": "CGST",
+                  "taxRate": "9",
+                  "taxAmount": {
+                    "currencyCode": "INR",
+                    "amount": "19697.98"
+                  },
+                  "taxableAmount": {
+                    "currencyCode": "INR",
+                    "amount": "218866.43"
+                  }
+                }
+              ],
+              "chargeDetails": [
+                {
+                  "type": "Freight",
+                  "description": "Freight Charges",
+                  "chargeAmount": {
+                    "currencyCode": "INR",
+                    "amount": "1200.00"
+                  },
+                  "taxDetails": [
+                    {
+                      "taxType": "CGST",
+                      "taxRate": "9",
+                      "taxAmount": {
+                        "currencyCode": "INR",
+                        "amount": "108.00"
+                      },
+                      "taxableAmount": {
+                        "currencyCode": "INR",
+                        "amount": "1200.00"
+                      }
+                    },
+                    {
+                      "taxType": "SGST",
+                      "taxRate": "9",
+                      "taxAmount": {
+                        "currencyCode": "INR",
+                        "amount": "108.00"
+                      },
+                      "taxableAmount": {
+                        "currencyCode": "INR",
+                        "amount": "1200.00"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "items": [
+                {
+                  "itemSequenceNumber": 1,
+                  "amazonProductIdentifier": "ABC123434",
+                  "vendorProductIdentifier": "809281-5100",
+                  "invoicedQuantity": {
+                    "amount": 2,
+                    "unitOfMeasure": "Eaches"
+                  },
+                  "netCost": {
+                    "currencyCode": "INR",
+                    "amount": "21060.34"
+                  },
+                  "purchaseOrderNumber": "3DY3TK6T",
+                  "hsnCode": "76.06.92.99.00",
+                  "taxDetails": [
+                    {
+                      "taxType": "SGST",
+                      "taxRate": "9",
+                      "taxAmount": {
+                        "currencyCode": "INR",
+                        "amount": "1895.43"
+                      },
+                      "taxableAmount": {
+                        "currencyCode": "INR",
+                        "amount": "21060.34"
+                      }
+                    },
+                    {
+                      "taxType": "CGST",
+                      "taxRate": "9",
+                      "taxAmount": {
+                        "currencyCode": "INR",
+                        "amount": "1895.43"
+                      },
+                      "taxableAmount": {
+                        "currencyCode": "INR",
+                        "amount": "21060.34"
+                      }
+                    }
+                  ],
+                  "chargeDetails": [
+                    {
+                      "type": "Freight",
+                      "description": "Freight Charges",
+                      "chargeAmount": {
+                        "currencyCode": "INR",
+                        "amount": "600.00"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "itemSequenceNumber": 2,
+                  "amazonProductIdentifier": "ABC123435",
+                  "vendorProductIdentifier": "795000-0001",
+                  "invoicedQuantity": {
+                    "amount": 3,
+                    "unitOfMeasure": "Eaches"
+                  },
+                  "netCost": {
+                    "currencyCode": "INR",
+                    "amount": "58915.25"
+                  },
+                  "purchaseOrderNumber": "3DY3TK6T",
+                  "taxDetails": [
+                    {
+                      "taxType": "SGST",
+                      "taxRate": "9",
+                      "taxAmount": {
+                        "currencyCode": "INR",
+                        "amount": "5302.37"
+                      },
+                      "taxableAmount": {
+                        "currencyCode": "INR",
+                        "amount": "58915.25"
+                      }
+                    },
+                    {
+                      "taxType": "CGST",
+                      "taxRate": "9",
+                      "taxAmount": {
+                        "currencyCode": "INR",
+                        "amount": "5302.37"
+                      },
+                      "taxableAmount": {
+                        "currencyCode": "INR",
+                        "amount": "58915.25"
+                      }
+                    }
+                  ],
+                  "chargeDetails": [
+                    {
+                      "type": "Freight",
+                      "description": "Freight Charges",
+                      "chargeAmount": {
+                        "currencyCode": "INR",
+                        "amount": "600.00"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
     },
     "Invoice": {
       "type": "object",


### PR DESCRIPTION
When generating TS client with the [Openapi generator](https://openapi-generator.tech/) with [vendorInvoices.json](https://github.com/amzn/selling-partner-api-models/blob/main/models/vendor-invoices-api-model/vendorInvoices.json)

This error occurred :

```
Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 1, Warning count: 1
Errors: 
        -attribute paths.'/vendor/payments/v1/invoices'(post).[body].example is unexpected
Warnings: 
        -attribute paths.'/vendor/payments/v1/invoices'(post).[body].example is unexpected

        at org.openapitools.codegen.config.CodegenConfigurator.toContext(CodegenConfigurator.java:546)
        at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:573)
        at org.openapitools.codegen.cmd.Generate.execute(Generate.java:432)
        at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
        at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
```

Sibling values alongside $refs are ignored.

The solution is to use allOf or add the example property during the definition of the schema

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
