### PR TITLE
Fix vendorOrders.json

### DIFF
--- a/models/vendor-orders-api-model/vendorOrders.json
+++ b/models/vendor-orders-api-model/vendorOrders.json
@@ -1558,53 +1558,7 @@
             "name": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/SubmitAcknowledgementRequest",
-              "example": {
-                "payload": {
-                  "acknowledgements": [
-                    {
-                      "purchaseOrderNumber": "L8266355",
-                      "sellingParty": {
-                        "partyId": "999US"
-                      },
-                      "acknowledgementDate": "2019-07-17T19:17:34.304Z",
-                      "items": [
-                        {
-                          "itemSequenceNumber": "1",
-                          "amazonProductIdentifier": "ABC123434",
-                          "vendorProductIdentifier": "028877454078",
-                          "orderedQuantity": {
-                            "amount": 10,
-                            "unitOfMeasure": "Cases"
-                          },
-                          "netCost": {
-                            "currencyCode": "USD",
-                            "amount": "10.2"
-                          },
-                          "listPrice": {
-                            "currencyCode": "USD",
-                            "amount": "22.2"
-                          },
-                          "discountMultiplier": "0.44",
-                          "itemAcknowledgements": [
-                            {
-                              "acknowledgementCode": "Rejected",
-                              "acknowledgedQuantity": {
-                                "amount": 6,
-                                "unitOfMeasure": "Cases",
-                                "unitSize": 2
-                              },
-                              "scheduledShipDate": "2019-07-17T19:17:34.304Z",
-                              "scheduledDeliveryDate": "2019-07-17T19:17:34.304Z",
-                              "rejectionReason": "TemporarilyUnavailable"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
+              "$ref": "#/definitions/SubmitAcknowledgementRequest"
             }
           }
         ],
@@ -3236,7 +3190,53 @@
           }
         }
       },
-      "description": "The request schema for the submitAcknowledgment operation."
+      "description": "The request schema for the submitAcknowledgment operation.",
+      "example": {
+        "payload": {
+          "acknowledgements": [
+            {
+              "purchaseOrderNumber": "L8266355",
+              "sellingParty": {
+                "partyId": "999US"
+              },
+              "acknowledgementDate": "2019-07-17T19:17:34.304Z",
+              "items": [
+                {
+                  "itemSequenceNumber": "1",
+                  "amazonProductIdentifier": "ABC123434",
+                  "vendorProductIdentifier": "028877454078",
+                  "orderedQuantity": {
+                    "amount": 10,
+                    "unitOfMeasure": "Cases"
+                  },
+                  "netCost": {
+                    "currencyCode": "USD",
+                    "amount": "10.2"
+                  },
+                  "listPrice": {
+                    "currencyCode": "USD",
+                    "amount": "22.2"
+                  },
+                  "discountMultiplier": "0.44",
+                  "itemAcknowledgements": [
+                    {
+                      "acknowledgementCode": "Rejected",
+                      "acknowledgedQuantity": {
+                        "amount": 6,
+                        "unitOfMeasure": "Cases",
+                        "unitSize": 2
+                      },
+                      "scheduledShipDate": "2019-07-17T19:17:34.304Z",
+                      "scheduledDeliveryDate": "2019-07-17T19:17:34.304Z",
+                      "rejectionReason": "TemporarilyUnavailable"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
     },
     "OrderAcknowledgement": {
       "type": "object",


### PR DESCRIPTION
When generating TS client with the [Openapi generator](https://openapi-generator.tech/) with [vendorOrders.json](https://github.com/amzn/selling-partner-api-models/blob/main/models/vendor-orders-api-model/vendorOrders.json)

This error occurred :

```
Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 1, Warning count: 0
Errors:
        -attribute paths.'/vendor/orders/v1/acknowledgements'(post).[body].example is unexpected
        at org.openapitools.codegen.config.CodegenConfigurator.toContext(CodegenConfigurator.java:546)
        at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:573)
        at org.openapitools.codegen.cmd.Generate.execute(Generate.java:432)
        at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
        at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
```

Sibling values alongside $refs are ignored.

The solution is to use `allOff` or add the example property during the definition of the schema

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
