### PR TITLE
Fix vendorShipments.json

### DIFF
--- a/models/vendor-shipments-api-model/vendorShipments.json
+++ b/models/vendor-shipments-api-model/vendorShipments.json
@@ -37,181 +37,7 @@
             "name": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/SubmitShipmentConfirmationsRequest",
-              "example": {
-                "shipmentConfirmations": [
-                  {
-                    "shipmentIdentifier": "00050003",
-                    "shipmentConfirmationType": "Original",
-                    "shipmentType": "LessThanTruckLoad",
-                    "shipmentStructure": "PalletizedStandardCase",
-                    "transportationDetails": {
-                      "transportationMode": "Road",
-                      "billOfLadingNumber": "02440000"
-                    },
-                    "shipmentConfirmationDate": "2019-08-07T19:56:45.632Z",
-                    "shippedDate": "2019-08-07T19:56:45.632Z",
-                    "estimatedDeliveryDate": "2019-08-07T19:56:45.632Z",
-                    "sellingParty": {
-                      "partyId": "VENDORCODE"
-                    },
-                    "shipFromParty": {
-                      "address": {
-                        "name": "ABC electronics warehouse",
-                        "addressLine1": "DEF 1st street",
-                        "city": "Lisses",
-                        "stateOrRegion": "abcland",
-                        "postalCode": "91090",
-                        "countryCode": "DE"
-                      },
-                      "partyId": "VENDORWAREHOUSECODE"
-                    },
-                    "shipToParty": {
-                      "partyId": "AMZWAREHOUSECODE"
-                    },
-                    "shipmentMeasurements": {
-                      "grossShipmentWeight": {
-                        "unitOfMeasure": "Kg",
-                        "value": "120.45"
-                      },
-                      "shipmentVolume": {
-                        "unitOfMeasure": "CuFt",
-                        "value": "2.4"
-                      },
-                      "palletCount": 1
-                    },
-                    "shippedItems": [
-                      {
-                        "itemSequenceNumber": "001",
-                        "vendorProductIdentifier": "9782700001659",
-                        "shippedQuantity": {
-                          "amount": 100,
-                          "unitOfMeasure": "Eaches",
-                          "unitSize": 1
-                        },
-                        "itemDetails": {
-                          "purchaseOrderNumber": "1BBBAAAA",
-                          "lotNumber": "1045",
-                          "maximumRetailPrice": {
-                            "currencyCode": "EUR",
-                            "amount": "299.00"
-                          },
-                          "handlingCode": "Oversized"
-                        }
-                      }
-                    ],
-                    "cartons": [
-                      {
-                        "cartonIdentifiers": [
-                          {
-                            "containerIdentificationType": "SSCC",
-                            "containerIdentificationNumber": "00102234567666698888"
-                          }
-                        ],
-                        "cartonSequenceNumber": "001",
-                        "items": [
-                          {
-                            "itemReference": "001",
-                            "shippedQuantity": {
-                              "amount": 25,
-                              "unitOfMeasure": "Eaches",
-                              "unitSize": 1
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "cartonIdentifiers": [
-                          {
-                            "containerIdentificationType": "SSCC",
-                            "containerIdentificationNumber": "00102234567666699999"
-                          }
-                        ],
-                        "cartonSequenceNumber": "002",
-                        "items": [
-                          {
-                            "itemReference": "001",
-                            "shippedQuantity": {
-                              "amount": 25,
-                              "unitOfMeasure": "Eaches",
-                              "unitSize": 1
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "cartonIdentifiers": [
-                          {
-                            "containerIdentificationType": "SSCC",
-                            "containerIdentificationNumber": "00102234567666696666"
-                          }
-                        ],
-                        "cartonSequenceNumber": "003",
-                        "items": [
-                          {
-                            "itemReference": "001",
-                            "shippedQuantity": {
-                              "amount": 25,
-                              "unitOfMeasure": "Eaches",
-                              "unitSize": 1
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "cartonIdentifiers": [
-                          {
-                            "containerIdentificationType": "SSCC",
-                            "containerIdentificationNumber": "00102234567666697777"
-                          }
-                        ],
-                        "cartonSequenceNumber": "004",
-                        "items": [
-                          {
-                            "itemReference": "001",
-                            "shippedQuantity": {
-                              "amount": 25,
-                              "unitOfMeasure": "Eaches",
-                              "unitSize": 1
-                            }
-                          }
-                        ]
-                      }
-                    ],
-                    "pallets": [
-                      {
-                        "palletIdentifiers": [
-                          {
-                            "containerIdentificationType": "SSCC",
-                            "containerIdentificationNumber": "00102234567898098745"
-                          }
-                        ],
-                        "tier": 2,
-                        "block": 2,
-                        "dimensions": {
-                          "length": "1.2",
-                          "width": "0.8",
-                          "height": "1",
-                          "unitOfMeasure": "In"
-                        },
-                        "weight": {
-                          "unitOfMeasure": "Kg",
-                          "value": "120.45"
-                        },
-                        "cartonReferenceDetails": {
-                          "cartonCount": 4,
-                          "cartonReferenceNumbers": [
-                            "001",
-                            "002",
-                            "003",
-                            "004"
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
+              "$ref": "#/definitions/SubmitShipmentConfirmationsRequest"
             }
           }
         ],
@@ -412,7 +238,181 @@
           }
         }
       },
-      "description": "The request schema for the SubmitShipmentConfirmations operation."
+      "description": "The request schema for the SubmitShipmentConfirmations operation.",
+      "example": {
+        "shipmentConfirmations": [
+          {
+            "shipmentIdentifier": "00050003",
+            "shipmentConfirmationType": "Original",
+            "shipmentType": "LessThanTruckLoad",
+            "shipmentStructure": "PalletizedStandardCase",
+            "transportationDetails": {
+              "transportationMode": "Road",
+              "billOfLadingNumber": "02440000"
+            },
+            "shipmentConfirmationDate": "2019-08-07T19:56:45.632Z",
+            "shippedDate": "2019-08-07T19:56:45.632Z",
+            "estimatedDeliveryDate": "2019-08-07T19:56:45.632Z",
+            "sellingParty": {
+              "partyId": "VENDORCODE"
+            },
+            "shipFromParty": {
+              "address": {
+                "name": "ABC electronics warehouse",
+                "addressLine1": "DEF 1st street",
+                "city": "Lisses",
+                "stateOrRegion": "abcland",
+                "postalCode": "91090",
+                "countryCode": "DE"
+              },
+              "partyId": "VENDORWAREHOUSECODE"
+            },
+            "shipToParty": {
+              "partyId": "AMZWAREHOUSECODE"
+            },
+            "shipmentMeasurements": {
+              "grossShipmentWeight": {
+                "unitOfMeasure": "Kg",
+                "value": "120.45"
+              },
+              "shipmentVolume": {
+                "unitOfMeasure": "CuFt",
+                "value": "2.4"
+              },
+              "palletCount": 1
+            },
+            "shippedItems": [
+              {
+                "itemSequenceNumber": "001",
+                "vendorProductIdentifier": "9782700001659",
+                "shippedQuantity": {
+                  "amount": 100,
+                  "unitOfMeasure": "Eaches",
+                  "unitSize": 1
+                },
+                "itemDetails": {
+                  "purchaseOrderNumber": "1BBBAAAA",
+                  "lotNumber": "1045",
+                  "maximumRetailPrice": {
+                    "currencyCode": "EUR",
+                    "amount": "299.00"
+                  },
+                  "handlingCode": "Oversized"
+                }
+              }
+            ],
+            "cartons": [
+              {
+                "cartonIdentifiers": [
+                  {
+                    "containerIdentificationType": "SSCC",
+                    "containerIdentificationNumber": "00102234567666698888"
+                  }
+                ],
+                "cartonSequenceNumber": "001",
+                "items": [
+                  {
+                    "itemReference": "001",
+                    "shippedQuantity": {
+                      "amount": 25,
+                      "unitOfMeasure": "Eaches",
+                      "unitSize": 1
+                    }
+                  }
+                ]
+              },
+              {
+                "cartonIdentifiers": [
+                  {
+                    "containerIdentificationType": "SSCC",
+                    "containerIdentificationNumber": "00102234567666699999"
+                  }
+                ],
+                "cartonSequenceNumber": "002",
+                "items": [
+                  {
+                    "itemReference": "001",
+                    "shippedQuantity": {
+                      "amount": 25,
+                      "unitOfMeasure": "Eaches",
+                      "unitSize": 1
+                    }
+                  }
+                ]
+              },
+              {
+                "cartonIdentifiers": [
+                  {
+                    "containerIdentificationType": "SSCC",
+                    "containerIdentificationNumber": "00102234567666696666"
+                  }
+                ],
+                "cartonSequenceNumber": "003",
+                "items": [
+                  {
+                    "itemReference": "001",
+                    "shippedQuantity": {
+                      "amount": 25,
+                      "unitOfMeasure": "Eaches",
+                      "unitSize": 1
+                    }
+                  }
+                ]
+              },
+              {
+                "cartonIdentifiers": [
+                  {
+                    "containerIdentificationType": "SSCC",
+                    "containerIdentificationNumber": "00102234567666697777"
+                  }
+                ],
+                "cartonSequenceNumber": "004",
+                "items": [
+                  {
+                    "itemReference": "001",
+                    "shippedQuantity": {
+                      "amount": 25,
+                      "unitOfMeasure": "Eaches",
+                      "unitSize": 1
+                    }
+                  }
+                ]
+              }
+            ],
+            "pallets": [
+              {
+                "palletIdentifiers": [
+                  {
+                    "containerIdentificationType": "SSCC",
+                    "containerIdentificationNumber": "00102234567898098745"
+                  }
+                ],
+                "tier": 2,
+                "block": 2,
+                "dimensions": {
+                  "length": "1.2",
+                  "width": "0.8",
+                  "height": "1",
+                  "unitOfMeasure": "In"
+                },
+                "weight": {
+                  "unitOfMeasure": "Kg",
+                  "value": "120.45"
+                },
+                "cartonReferenceDetails": {
+                  "cartonCount": 4,
+                  "cartonReferenceNumbers": [
+                    "001",
+                    "002",
+                    "003",
+                    "004"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
     },
     "ShipmentConfirmation": {
       "type": "object",


### PR DESCRIPTION
When generating TS client with the [Openapi generator](https://openapi-generator.tech/) with [vendorShipments.json](https://github.com/amzn/selling-partner-api-models/blob/main/models/vendor-shipments-api-model/vendorShipments.json)

This error occurred :

```
Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 1, Warning count: 0
Errors:
        -attribute paths.'/vendor/shipping/v1/shipmentConfirmations'(post).[body].example is unexpected
        at org.openapitools.codegen.config.CodegenConfigurator.toContext(CodegenConfigurator.java:546)
        at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:573)
        at org.openapitools.codegen.cmd.Generate.execute(Generate.java:432)
        at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
        at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
```

Sibling values alongside $refs are ignored.

The solution is to use `allOf` or add the example property during the definition of the schema

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
