### PR TITLE
Update catalogItems schema to reflect the actual data that's returned

### DIFF
--- a/models/catalog-items-api-model/catalogItems_2020-12-01.json
+++ b/models/catalog-items-api-model/catalogItems_2020-12-01.json
@@ -1049,7 +1049,7 @@
         "productTypes": {
           "$ref": "#/definitions/ItemProductTypes"
         },
-        "salesRanks": {
+        "ranks": {
           "$ref": "#/definitions/ItemSalesRanks"
         },
         "summaries": {
@@ -1294,7 +1294,7 @@
           "description": "Corresponding Amazon retail website link, or URL, for the sales rank.",
           "type": "string"
         },
-        "rank": {
+        "value": {
           "description": "Sales rank value.",
           "type": "integer"
         }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

As noted [here](https://github.com/amzn/selling-partner-api-models/issues/139), the field returned for sales ranks is misnamed, and one of its subfields is also misnamed in the schema.  This update fixes those inconsistencies.