### PR TITLE
mvn package error.

### DIFF
--- a/clients/sellingpartner-api-aa-java/pom.xml
+++ b/clients/sellingpartner-api-aa-java/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.8</version>
+            <version>1.18.20</version>
             <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->


### PR DESCRIPTION
I compile the sellingpartner-api-aa-java. but it was fail.

# env

```
> java -version
openjdk version "17" 2021-09-14
OpenJDK Runtime Environment Homebrew (build 17+0)
OpenJDK 64-Bit Server VM Homebrew (build 17+0, mixed mode)

> javac -version
javac 17
```


# error

```
> mvn package
[INFO] Scanning for projects...
[INFO]
[INFO] -------< com.amazon.sellingpartnerapi:sellingpartnerapi-aa-java >-------
[INFO] Building sellingpartnerapi-aa-java 1.0
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ sellingpartnerapi-aa-java ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /Users/yasui/develop/f-ama/selling-partner-api-models/clients/sellingpartner-api-aa-java/src/main/resources
[INFO]
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ sellingpartnerapi-aa-java ---
[INFO] Changes detected - recompiling the module!
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[INFO] Compiling 16 source files to /Users/yasui/develop/f-ama/selling-partner-api-models/clients/sellingpartner-api-aa-java/target/classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.721 s
[INFO] Finished at: 2021-08-25T17:11:48+09:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project sellingpartnerapi-aa-java: Fatal error compiling: java.lang.IllegalAccessError: class lombok.javac.apt.LombokProcessor (in unnamed module @0x6cfbbff7) cannot access class com.sun.tools.javac.processing.JavacProcessingEnvironment (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.processing to unnamed module @0x6cfbbff7 -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
