### PR TITLE
Handle requests with arrays in query string

### DIFF
--- a/clients/sellingpartner-api-aa-csharp/src/Amazon.SellingPartnerAPIAA/AWSSignerHelper.cs
+++ b/clients/sellingpartner-api-aa-csharp/src/Amazon.SellingPartnerAPIAA/AWSSignerHelper.cs
@@ -74,24 +74,20 @@ namespace Amazon.SellingPartnerAPIAA
         /// <returns>Query parameters in canonical order with URL encoding</returns>
         public virtual string ExtractCanonicalQueryString(IRestRequest request)
         {
-            IDictionary<string, string> queryParameters = request.Parameters
-                .Where(parameter => ParameterType.QueryString.Equals(parameter.Type))
-                .ToDictionary(header => header.Name.Trim().ToString(), header => header.Value.ToString());
-
-            SortedDictionary<string, string> sortedqueryParameters = new SortedDictionary<string, string>(queryParameters);
+            IEnumerable<Parameter> queryParameters = request.Parameters
+                .Where(parameter => ParameterType.QueryString.Equals(parameter.Type)).OrderBy(p => (p.Name ?? "") + p.Value);
 
             StringBuilder canonicalQueryString = new StringBuilder();
-            foreach (var key in sortedqueryParameters.Keys)
+            foreach (var parameter in queryParameters)
             {
                 if (canonicalQueryString.Length > 0)
                 {
                     canonicalQueryString.Append("&");
                 }
                 canonicalQueryString.AppendFormat("{0}={1}",
-                    Utils.UrlEncode(key),
-                    Utils.UrlEncode(sortedqueryParameters[key]));
+                    Utils.UrlEncode(parameter.Name?.Trim()),
+                    Utils.UrlEncode(parameter.Value?.ToString()));
             }
-
             return canonicalQueryString.ToString();
         }
 

--- a/clients/sellingpartner-api-aa-csharp/test/Amazon.SellingPartnerAPIAATests/AWSSignerHelperTest.cs
+++ b/clients/sellingpartner-api-aa-csharp/test/Amazon.SellingPartnerAPIAATests/AWSSignerHelperTest.cs
@@ -96,6 +96,18 @@ namespace Amazon.SellingPartnerAPIAATests
         }
 
         [Fact]
+        public void TestExtractCanonicalQueryString_ParameterArray()
+        {
+            IRestRequest request = new RestRequest();
+            //Add parameters in non-alphabetical order
+            request.AddQueryParameter("Statuses", "New");
+            request.AddQueryParameter("Statuses", "Complete");
+            string result = awsSignerHelperUnderTest.ExtractCanonicalQueryString(request);
+            //Expect result in alphabetical order
+            Assert.Equal("Statuses=Complete&Statuses=New", result);
+        }
+
+        [Fact]
         public void TestExtractCanonicalHeaders()
         {
             IRestRequest request = new RestRequest();


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Seller api endpoint GET /orders/v0/orders accepts an array of OrderStatuses in the query. 
https://github.com/amzn/selling-partner-api-docs/blob/main/references/orders-api/ordersV0.md#getorders

When attempting to sign a request that has more than one parameter with the same name we get an error when populating a Dictionary.

**Example of building the request:**
```
IRestRequest restRequest= new RestRequest();
foreach (string status in orderStatuses)
{
    restRequest.AddParameter("OrderStatuses", status, ParameterType.QueryString);
}
AWSSigV4Signer.Sign(restRequest," "sellingpartnerapi-eu.amazon.com")
```

**Example of the runtime error:**
```
System.ArgumentException
An item with the same key has already been added. Key: Statuses
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
   at Amazon.SellingPartnerAPIAA.AWSSignerHelper.ExtractCanonicalQueryString(IRestRequest request) in C:\temp\selling-partner-api-models\clients\sellingpartner-api-aa-csharp\src\Amazon.SellingPartnerAPIAA\AWSSignerHelper.cs:line 77
   at Amazon.SellingPartnerAPIAATests.AWSSignerHelperTest.TestExtractCanonicalQueryString_ParameterArray() in C:\temp\selling-partner-api-models\clients\sellingpartner-api-aa-csharp\test\Amazon.SellingPartnerAPIAATests\AWSSignerHelperTest.cs:line 105
```

This change removes the need for a dictionary and also ensures the query parameters are ordered by name and value before building the canonicalQueryString
