### PR TITLE
Fix improper unit value in dimensions (IN -> inches)

### DIFF
--- a/models/fulfillment-inbound-api-model/fulfillmentInboundV0.json
+++ b/models/fulfillment-inbound-api-model/fulfillmentInboundV0.json
@@ -1772,7 +1772,7 @@
                                 "Length": 11.0,
                                 "Width": 11.0,
                                 "Height": 11.0,
-                                "Unit": "IN"
+                                "Unit": "inches"
                               },
                               "Weight": {
                                 "Value": 11.0,


### PR DESCRIPTION
According to the [Dimensions schema](https://github.com/amzn/selling-partner-api-docs/blob/main/references/fulfillment-inbound-api/fulfillmentInboundV0.md#dimensions) there are only [two valid values](https://github.com/amzn/selling-partner-api-docs/blob/main/references/fulfillment-inbound-api/fulfillmentInboundV0.md#unitofmeasurement) for Unit: "inches" and "centimeters".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
