### PR TITLE
Add required tracking ID to getTransportDetails response

### DIFF
--- a/models/fulfillment-inbound-api-model/fulfillmentInboundV0.json
+++ b/models/fulfillment-inbound-api-model/fulfillmentInboundV0.json
@@ -1779,6 +1779,7 @@
                                 "Unit": "pounds"
                               },
                               "CarrierName": "UNITED_PARCEL_SERVICE_INC",
+                              "TrackingId": "1Z9999999999999999",
                               "PackageStatus": "SHIPPED"
                             }
                           ]


### PR DESCRIPTION
According to the [PartneredSmallParcelPackageOutput schema](https://github.com/amzn/selling-partner-api-docs/blob/main/references/fulfillment-inbound-api/fulfillmentInboundV0.md#partneredsmallparcelpackageoutput) the TrackingId is a required property.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
