### PR TITLE
Add required AreCasesRequired to getShipments

### DIFF
--- a/models/fulfillment-inbound-api-model/fulfillmentInboundV0.json
+++ b/models/fulfillment-inbound-api-model/fulfillmentInboundV0.json
@@ -3510,6 +3510,7 @@
                           "CountryCode": "US",
                           "PostalCode": "98109"
                         },
+                        "AreCasesRequired": false,
                         "DestinationFulfillmentCenterId": "MKC6",
                         "ShipmentStatus": "SHIPPED",
                         "LabelPrepType": "SELLER_LABEL",


### PR DESCRIPTION
According to the [InboundShipmentInfo schema](https://github.com/amzn/selling-partner-api-docs/blob/main/references/fulfillment-inbound-api/fulfillmentInboundV0.md#inboundshipmentinfo), the AreCasesRequired property is required. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
