### PR TITLE
Update the org.projectlombok version to 1.18.20

### DIFF
--- a/clients/sellingpartner-api-aa-java/pom.xml
+++ b/clients/sellingpartner-api-aa-java/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.8</version>
+            <version>1.18.20</version>
             <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->


### PR DESCRIPTION
This will fix the issue described below while running on JDK16:
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project sellingpartnerapi-aa-java: Fatal error compiling: java.lang.IllegalAccessError: class lombok.javac.apt.LombokProcessor (in unnamed module @0x1a8b81e8) cannot access class com.sun.tools.javac.processing.JavacProcessingEnvironment (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.processing to unnamed module @0x1a8b81e8 -> [Help 1]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
