### PR TITLE
Fix "examples" in /sellers/v1/marketplaceParticipations

### DIFF
--- a/models/sellers-api-model/sellers.json
+++ b/models/sellers-api-model/sellers.json
@@ -39,22 +39,24 @@
               "$ref": "#/definitions/GetMarketplaceParticipationsResponse"
             },
             "examples": {
-              "payload": [
-                {
-                  "marketplace": {
-                    "id": "ATVPDKIKX0DER",
-                    "name": "Amazon.com",
-                    "countryCode": "US",
-                    "defaultCurrencyCode": "USD",
-                    "defaultLanguageCode": "en_US",
-                    "domainName": "www.amazon.com"
-                  },
-                  "participation": {
-                    "isParticipating": true,
-                    "hasSuspendedListings": false
+              "application/json": {
+                "payload": [
+                  {
+                    "marketplace": {
+                      "id": "ATVPDKIKX0DER",
+                      "name": "Amazon.com",
+                      "countryCode": "US",
+                      "defaultCurrencyCode": "USD",
+                      "defaultLanguageCode": "en_US",
+                      "domainName": "www.amazon.com"
+                    },
+                    "participation": {
+                      "isParticipating": true,
+                      "hasSuspendedListings": false
+                    }
                   }
-                }
-              ]
+                ]
+              }
             },
             "headers": {
               "x-amzn-RateLimit-Limit": {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Swagger 2.0 describes response examples as mapping with MIME type:
https://swagger.io/docs/specification/2-0/adding-examples/

> Swagger allows examples on the response level, each example corresponding to a specific MIME type returned by the operation. Such as one example for application/json, another one for text/csv and so on. Each MIME type must be one of the operation’s produces values -- either explicit or inherited from the global scope.