### PR TITLE
fix(ordersV0): use same tag for new shipment route

### DIFF
--- a/models/orders-api-model/ordersV0.json
+++ b/models/orders-api-model/ordersV0.json
@@ -1757,7 +1757,7 @@
     "/orders/v0/orders/{orderId}/shipment": {
       "post": {
         "tags": [
-          "shipment"
+          "ordersV0"
         ],
         "description": "Update the shipment status.",
         "operationId": "updateShipmentStatus",


### PR DESCRIPTION
Most OpenAPI generators use tags to create different API clients, as documented in the spec (https://spec.openapis.org/oas/v3.0.3#fixed-fields-7).

This PR unifies the tags for the orderV0 API by updating the tag on the new `/orders/v0/orders/{orderId}/shipment` route.

@jevoniuk could you please take a look at this?

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
