### PR TITLE
fix LWAAccessTokenCache: LWAClientScopes missing EqualsAndHashCode

### DIFF
--- a/clients/sellingpartner-api-aa-java/src/com/amazon/SellingPartnerAPIAA/LWAClientScopes.java
+++ b/clients/sellingpartner-api-aa-java/src/com/amazon/SellingPartnerAPIAA/LWAClientScopes.java
@@ -3,6 +3,7 @@ package com.amazon.SellingPartnerAPIAA;
 
 import com.google.gson.annotations.JsonAdapter;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.Set;
@@ -10,6 +11,7 @@ import java.util.Set;
 @AllArgsConstructor
 @Getter
 @JsonAdapter(LWAClientScopesSerializerDeserializer.class)
+@EqualsAndHashCode
 public class LWAClientScopes {
 
     private final Set<String> scopes;

--- a/clients/sellingpartner-api-aa-java/tst/com/amazon/SellingPartnerAPIAA/LWAAccessTokenRequestMetaTest.java
+++ b/clients/sellingpartner-api-aa-java/tst/com/amazon/SellingPartnerAPIAA/LWAAccessTokenRequestMetaTest.java
@@ -1,0 +1,22 @@
+package com.amazon.SellingPartnerAPIAA;
+
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class LWAAccessTokenRequestMetaTest {
+
+    @Test
+    public void testEquals() {
+        LWAAccessTokenRequestMeta meta1 = new LWAAccessTokenRequestMeta(
+                "test","test","test","test",
+                new LWAClientScopes(Collections.emptySet()));
+        LWAAccessTokenRequestMeta meta2 = new LWAAccessTokenRequestMeta(
+                "test","test","test","test",
+                new LWAClientScopes(Collections.emptySet()));
+        assertEquals(meta1, meta2);
+    }
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
