### PR TITLE
[JAVA] Fix Connection Leak

### DIFF
--- a/clients/sellingpartner-api-aa-java/src/com/amazon/SellingPartnerAPIAA/LWAClient.java
+++ b/clients/sellingpartner-api-aa-java/src/com/amazon/SellingPartnerAPIAA/LWAClient.java
@@ -60,6 +60,7 @@ class LWAClient {
         try {
             Response response = okHttpClient.newCall(accessTokenRequest).execute();
             if (!response.isSuccessful()) {
+                response.body().close();
                 throw new IOException("Unsuccessful LWA token exchange");
             }
 


### PR DESCRIPTION
When LWA token exchange fails (`!response.isSuccessful()`), then the okhttp Response Body is never closed.
This leads to a connection leak and will eventually crash the application (dependent on the architecture)