### PR TITLE
Fix RDT Token Flow and Amazon SP-API C# SDK

### DIFF
--- a/clients/sellingpartner-api-aa-csharp/src/Amazon.SellingPartnerAPIAA/resources/swagger-codegen/templates/ApiClient.mustache
+++ b/clients/sellingpartner-api-aa-csharp/src/Amazon.SellingPartnerAPIAA/resources/swagger-codegen/templates/ApiClient.mustache
@@ -48,7 +48,10 @@ namespace {{packageName}}.Client
         /// <param name="request">The RestSharp request object</param>
         private void InterceptRequest(IRestRequest request)
         {
-            lwaAuthorizationSigner.Sign(request);
+            if (request.Parameters.Where(p => p.Name.Equals("x-amz-access-token")).ToList().Count() == 0)
+            {
+                lwaAuthorizationSigner.Sign(request);
+            }
             awsSigV4Signer.Sign(request, RestClient.BaseUrl.Host);
         }
 


### PR DESCRIPTION
Update ApiClient.mustache template to check if x-amz-access-token header has already been added to the request for restricted data requests before calling LWA token signer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
