### PR TITLE
fix(#289): getReSourcePath return excepted decode path

### DIFF
--- a/clients/sellingpartner-api-aa-java/src/com/amazon/SellingPartnerAPIAA/SignableRequestImpl.java
+++ b/clients/sellingpartner-api-aa-java/src/com/amazon/SellingPartnerAPIAA/SignableRequestImpl.java
@@ -74,7 +74,7 @@ class SignableRequestImpl implements SignableRequest<Request> {
     @Override
     public String getResourcePath() {
         return originalRequest.url()
-                .getPath();
+                .getRawPath();
     }
 
     @Override


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

fix: #289
