### PR TITLE
CSharp Handle values with slashes

### DIFF
--- a/clients/sellingpartner-api-aa-csharp/src/Amazon.SellingPartnerAPIAA/AWSSignerHelper.cs
+++ b/clients/sellingpartner-api-aa-csharp/src/Amazon.SellingPartnerAPIAA/AWSSignerHelper.cs
@@ -59,15 +59,19 @@ namespace Amazon.SellingPartnerAPIAA
                         .Where(parameter => ParameterType.UrlSegment.Equals(parameter.Type))
                         .ToDictionary(parameter => parameter.Name.Trim().ToString(), parameter => parameter.Value.ToString());
 
-                // Replace path parameter with actual value.
-                // Ex: /products/pricing/v0/items/{Asin}/offers -> /products/pricing/v0/items/AB12CD3E4Z/offers
-                foreach (string parameter in pathParameters.Keys)
+                // Split path at / into segments
+                // Doing this as the first step to handle values with slashes "/"
+                IEnumerable<string> encodedSegments = resource.Split(new char[] { '/' }, StringSplitOptions.None).Select(encodedSegment =>
                 {
-                    resource = resource.Replace("{" + parameter + "}", pathParameters[parameter]);
-                }
+                    // Replace path parameter with actual value.
+                    // Ex: /products/pricing/v0/items/{Asin}/offers -> /products/pricing/v0/items/AB12CD3E4Z/offers
+                    foreach (string parameter in pathParameters.Keys)
+                    {
+                        encodedSegment = encodedSegment.Replace("{" + parameter + "}", pathParameters[parameter]);
+                    }
 
-                //Split path at / into segments
-                IEnumerable<string> encodedSegments = resource.Split(new char[] { '/' }, StringSplitOptions.None);
+                    return encodedSegment;
+                });
 
                 // Encode twice
                 encodedSegments = encodedSegments.Select(segment => Utils.UrlEncode(segment));

--- a/clients/sellingpartner-api-aa-csharp/test/Amazon.SellingPartnerAPIAATests/AWSSignerHelperTest.cs
+++ b/clients/sellingpartner-api-aa-csharp/test/Amazon.SellingPartnerAPIAATests/AWSSignerHelperTest.cs
@@ -49,6 +49,16 @@ namespace Amazon.SellingPartnerAPIAATests
         }
 
         [Fact]
+        public void TestExtractCanonicalURIParameters_UrlSegmentsWithSlash()
+        {
+            IRestRequest request = new RestRequest("products/pricing/v0/items/{Asin}/offers/{SellerSKU}", Method.GET);
+            request.AddUrlSegment("Asin", "AB/12/CD/3/E/4/Z");
+            request.AddUrlSegment("SellerSKU", "1234567890");
+            string result = awsSignerHelperUnderTest.ExtractCanonicalURIParameters(request);
+            Assert.Equal("/products/pricing/v0/items/AB%252F12%252FCD%252F3%252FE%252F4%252FZ/offers/1234567890", result);
+        }
+
+        [Fact]
         public void TestExtractCanonicalURIParameters_IncorrectUrlSegment()
         {
             IRestRequest request = new RestRequest("products/pricing/v0/items/{Asin}/offers", Method.GET);
@@ -178,8 +188,8 @@ namespace Amazon.SellingPartnerAPIAATests
         {
             string expectedCanonicalHash = "foo";
             StringBuilder expectedStringBuilder = new StringBuilder();
-            expectedStringBuilder.AppendLine("AWS4-HMAC-SHA256");
-            expectedStringBuilder.AppendLine(ISOSigningDateTime);
+            expectedStringBuilder.Append("AWS4-HMAC-SHA256").Append("\n");
+            expectedStringBuilder.Append(ISOSigningDateTime).Append("\n");
             expectedStringBuilder.AppendFormat("{0}/{1}/execute-api/aws4_request\n", ISOSigningDate, TestRegion);
             expectedStringBuilder.Append(expectedCanonicalHash);
 


### PR DESCRIPTION
Doing "Split path at / into segments" as the first step to handle values with slashes "/".

Append "\n" instead of using AppendLine, so it matches AWSSignerHelper.BuildStringToSign()