### PR TITLE
Add "READY_TO_SHIP" as valid Fulfillment Inbound V0 "ShipmentStatus"

### DIFF
--- a/models/fulfillment-inbound-api-model/fulfillmentInboundV0.json
+++ b/models/fulfillment-inbound-api-model/fulfillmentInboundV0.json
@@ -6166,6 +6166,7 @@
       "description": "Indicates the status of the inbound shipment. When used with the createInboundShipment operation, WORKING is the only valid value. When used with the updateInboundShipment operation, possible values are WORKING, SHIPPED or CANCELLED.",
       "enum": [
         "WORKING",
+        "READY_TO_SHIP",
         "SHIPPED",
         "RECEIVING",
         "CANCELLED",
@@ -6180,6 +6181,10 @@
         {
           "value": "WORKING",
           "description": "The shipment was created by the seller, but has not yet shipped."
+        },
+        {
+          "value": "READY_TO_SHIP",
+          "description": "The seller has printed box labels (for Small parcel shipments) or pallet labels (for Less Than Truckload shipments)."
         },
         {
           "value": "SHIPPED",


### PR DESCRIPTION
Regarding Issue https://github.com/amzn/selling-partner-api-models/issues/270

The "READY_TO_SHIP" shipment status is accepted as a valid input value in the Fulfillment Inbound "getShipments" API call and has been returned as a valid "ShipmentStatus" enum value in responses.

The "READY_TO_SHIP" enum value has been added to the "ShipmentStatus" models enum value list.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
