### PR TITLE
Fix bad "getOrderItemsBuyerInfo" response example.

### DIFF
--- a/models/orders-api-model/ordersV0.json
+++ b/models/orders-api-model/ordersV0.json
@@ -1634,16 +1634,33 @@
             "examples": {
               "application/json": {
                 "payload": {
-                  "OrderItemId": "903-1671087-0812628",
-                  "BuyerCustomizedInfo": {
-                    "CustomizedURL": "https://zme-caps.amazon.com/t/bR6qHkzSOxuB/J8nbWhze0Bd3DkajkOdY-XQbWkFralegp2sr_QZiKEE/1"
-                  },
-                  "GiftMessageText": "For you!",
-                  "GiftWrapPrice": {
-                    "CurrencyCode": "JPY",
-                    "Amount": "1.99"
-                  },
-                  "GiftWrapLevel": "Classic"
+                  "AmazonOrderId": "903-1671087-0812628",
+                  "OrderItems": [
+                    {
+                      "OrderItemId": "68828574383266",
+                      "BuyerCustomizedInfo": {
+                        "CustomizedURL": "https://zme-caps.amazon.com/t/bR6qHkzSOxuB/J8nbWhze0Bd3DkajkOdY-XQbWkFralegp2sr_QZiKEE/1"
+                      },
+                      "GiftMessageText": "For you!",
+                      "GiftWrapPrice": {
+                        "CurrencyCode": "GBP",
+                        "Amount": "41.99"
+                      },
+                      "GiftWrapLevel": "Classic"
+                    },
+                    {
+                      "OrderItemId": "79039765272157",
+                      "BuyerCustomizedInfo": {
+                        "CustomizedURL": "https://zme-caps.amazon.com/t/bR6qHkzSOxuB/J8nbWhze0Bd3DkajkOdY-XQbWkFralegp2sr_QZiKEE/1"
+                      },
+                      "GiftMessageText": "For you!",
+                      "GiftWrapPrice": {
+                        "CurrencyCode": "JPY",
+                        "Amount": "1.99"
+                      },
+                      "GiftWrapLevel": "Classic"
+                    }
+                  ]
                 }
               }
             },


### PR DESCRIPTION
The previous example for a successful 200 response code did not match the structure of the "GetOrderItemsBuyerInfoResponse" response schema (see below).  It was missing the "OrderItemsBuyerInfoList" and "OrderItemBuyerInfoList" levels of the data structure, skipping straight to the "OrderItemBuyerInfo" level instead, where it had an incorrect value of "903-1671087-0812628" for "OrderItemId", which actually should have been the "AmazonOrderId" in the missing "OrderItemsBuyerInfoList" level of the structure.

To fix this example response, I started with the data from the example response for "getOrderItems", which was using the same "AmazonOrderId" value of "903-1671087-0812628".  I restructured the response data to match the correct response schema for this operation and removed the extraneous data.

The fixed example should be valid for the response schema:

    "GetOrderItemsBuyerInfoResponse": {
      "type": "object",
      "properties": {
        "payload": {
          "description": "The payload for the getOrderItemsBuyerInfo operation.",
          "$ref": "#/definitions/OrderItemsBuyerInfoList"
        },
        "errors": {
          "description": "One or more unexpected errors occurred during the getOrderItemsBuyerInfo operation.",
          "$ref": "#/definitions/ErrorList"
        }
      },
      "description": "The response schema for the getOrderItemsBuyerInfo operation."
    },
    "OrderItemsBuyerInfoList": {
      "type": "object",
      "required": [
        "AmazonOrderId",
        "OrderItems"
      ],
      "properties": {
        "OrderItems": {
          "$ref": "#/definitions/OrderItemBuyerInfoList"
        },
        "NextToken": {
          "type": "string",
          "description": "When present and not empty, pass this string token in the next request to return the next response page."
        },
        "AmazonOrderId": {
          "type": "string",
          "description": "An Amazon-defined order identifier, in 3-7-7 format."
        }
      },
      "description": "A single order item's buyer information list with the order ID."
    },
    "OrderItemBuyerInfoList": {
      "type": "array",
      "description": "A single order item's buyer information list.",
      "items": {
        "$ref": "#/definitions/OrderItemBuyerInfo"
      }
    },
    "OrderItemBuyerInfo": {
      "type": "object",
      "required": [
        "OrderItemId"
      ],
      "properties": {
        "OrderItemId": {
          "type": "string",
          "description": "An Amazon-defined order item identifier."
        },
        "BuyerCustomizedInfo": {
          "description": "Buyer information for custom orders from the Amazon Custom program.",
          "$ref": "#/definitions/BuyerCustomizedInfoDetail"
        },
        "GiftWrapPrice": {
          "description": "The gift wrap price of the item.",
          "$ref": "#/definitions/Money"
        },
        "GiftWrapTax": {
          "description": "The tax on the gift wrap price.",
          "$ref": "#/definitions/Money"
        },
        "GiftMessageText": {
          "type": "string",
          "description": "A gift message provided by the buyer."
        },
        "GiftWrapLevel": {
          "type": "string",
          "description": "The gift wrap level specified by the buyer."
        }
      },
      "description": "A single order item's buyer information."
    },

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
