### PR TITLE
Specified UTC date format for LastUpdatedAfter

### DIFF
--- a/models/orders-api-model/ordersV0.json
+++ b/models/orders-api-model/ordersV0.json
@@ -49,7 +49,7 @@
           {
             "name": "LastUpdatedAfter",
             "in": "query",
-            "description": "A date used for selecting orders that were last updated after (or at) a specified time. An update is defined as any change in order status, including the creation of a new order. Includes updates made by Amazon and by the seller. The date must be in ISO 8601 format.",
+            "description": "A date used for selecting orders that were last updated after (or at) a specified time. An update is defined as any change in order status, including the creation of a new order. Includes updates made by Amazon and by the seller. The date must be in ISO 8601 format with 'Z' to indicate UTC.",
             "required": false,
             "type": "string"
           },


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Specified UTC date format for LastUpdatedAfter as other time notations(eg: JTC) seems to throw an error.
