### PR TITLE
Java 17+ compatibility sellingpartner api aa java

### DIFF
--- a/clients/sellingpartner-api-aa-java/pom.xml
+++ b/clients/sellingpartner-api-aa-java/pom.xml
@@ -53,9 +53,10 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.8</version>
+            <version>1.18.34</version>
             <scope>provided</scope>
         </dependency>
+
         <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/clients/sellingpartner-api-aa-java/pom.xml
+++ b/clients/sellingpartner-api-aa-java/pom.xml
@@ -83,7 +83,6 @@
             <version>5.3.2</version>
             <scope>test</scope>
         </dependency>
-
         <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-migrationsupport -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/clients/sellingpartner-api-aa-java/pom.xml
+++ b/clients/sellingpartner-api-aa-java/pom.xml
@@ -56,7 +56,6 @@
             <version>1.18.34</version>
             <scope>provided</scope>
         </dependency>
-
         <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

The `pom.xml` contains a version of lombok, that doesn't work with java versions 17+ anymore. 
There have been a few older issues on that, but it was not fixed so far. 
