### PR TITLE
fix: Remove schema defaults for objects with required keys

### DIFF
--- a/schemas/notifications/AnyOfferChangedNotification.json
+++ b/schemas/notifications/AnyOfferChangedNotification.json
@@ -4,7 +4,6 @@
   "type": "object",
   "title": "The root schema",
   "description": "The root schema comprises the entire JSON document.",
-  "default": {},
   "examples": [
     {
       "NotificatonTionVersion": "1.0",
@@ -251,7 +250,6 @@
       "type": "object",
       "title": "The NotificationMetadata schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "ApplicationId": "app-id-d0e9e693-c3ad-4373-979f-ed4ec98dd746",
@@ -315,7 +313,6 @@
       "type": "object",
       "title": "The Payload schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "AnyOfferChangedNotification": {
@@ -505,7 +502,6 @@
           "type": "object",
           "title": "The AnyOfferChangedNotification schema",
           "description": "An explanation about the purpose of this instance.",
-          "default": {},
           "examples": [
             {
               "SellerId": "A3TH9S8BH6GOGM",
@@ -706,7 +702,6 @@
               "type": "object",
               "title": "The OfferChangeTrigger schema",
               "description": "An explanation about the purpose of this instance.",
-              "default": {},
               "examples": [
                 {
                   "MarketplaceId": "ATVPDKIKX0DER",
@@ -782,7 +777,6 @@
               "type": "object",
               "title": "The Summary schema",
               "description": "An explanation about the purpose of this instance.",
-              "default": {},
               "examples": [
                 {
                   "NumberOfOffers": [
@@ -952,7 +946,6 @@
                         "type": "object",
                         "title": "The first anyOf schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "Condition": "new",
@@ -1056,7 +1049,6 @@
                         "type": "object",
                         "title": "The first anyOf schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "Condition": "new",
@@ -1109,7 +1101,6 @@
                             "type": "object",
                             "title": "The LandedPrice schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
                             "examples": [
                               {
                                 "Amount": 10.0,
@@ -1149,7 +1140,6 @@
                             "type": "object",
                             "title": "The ListingPrice schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
                             "examples": [
                               {
                                 "Amount": 10.0,
@@ -1189,7 +1179,6 @@
                             "type": "object",
                             "title": "The Shipping schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
                             "examples": [
                               {
                                 "Amount": 0.0,
@@ -1231,7 +1220,6 @@
                         "type": "object",
                         "title": "The second anyOf schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "Condition": "old",
@@ -1288,7 +1276,6 @@
                             "type": "object",
                             "title": "The LandedPrice schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
                             "examples": [
                               {
                                 "Amount": 11.0,
@@ -1328,7 +1315,6 @@
                             "type": "object",
                             "title": "The ListingPrice schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
                             "examples": [
                               {
                                 "Amount": 20.0,
@@ -1368,7 +1354,6 @@
                             "type": "object",
                             "title": "The Shipping schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
                             "examples": [
                               {
                                 "Amount": 40.0,
@@ -1408,7 +1393,6 @@
                             "type": "object",
                             "title": "The Points schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
                             "examples": [
                               {
                                 "PointsNumber": 34343
@@ -1488,7 +1472,6 @@
                         "type": "object",
                         "title": "The first anyOf schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "Condition": "new",
@@ -1529,7 +1512,6 @@
                             "type": "object",
                             "title": "The LandedPrice schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
                             "examples": [
                               {
                                 "Amount": 10.0,
@@ -1569,7 +1551,6 @@
                             "type": "object",
                             "title": "The ListingPrice schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
                             "examples": [
                               {
                                 "Amount": 10.0,
@@ -1609,7 +1590,6 @@
                             "type": "object",
                             "title": "The Shipping schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
                             "examples": [
                               {
                                 "Amount": 0.0,
@@ -1651,7 +1631,6 @@
                         "type": "object",
                         "title": "The second anyOf schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "Condition": "old",
@@ -1696,7 +1675,6 @@
                             "type": "object",
                             "title": "The LandedPrice schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
                             "examples": [
                               {
                                 "Amount": 11.0,
@@ -1736,7 +1714,6 @@
                             "type": "object",
                             "title": "The ListingPrice schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
                             "examples": [
                               {
                                 "Amount": 20.0,
@@ -1776,7 +1753,6 @@
                             "type": "object",
                             "title": "The Shipping schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
                             "examples": [
                               {
                                 "Amount": 40.0,
@@ -1816,7 +1792,6 @@
                             "type": "object",
                             "title": "The Points schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
                             "examples": [
                               {
                                 "PointsNumber": 34343
@@ -1850,7 +1825,6 @@
                   "type": "object",
                   "title": "The ListPrice schema",
                   "description": "An explanation about the purpose of this instance.",
-                  "default": {},
                   "examples": [
                     {
                       "Amount": 55.0,
@@ -1890,7 +1864,6 @@
                   "type": "object",
                   "title": "The MinimumAdvertisedPrice schema",
                   "description": "An explanation about the purpose of this instance.",
-                  "default": {},
                   "examples": [
                     {
                       "Amount": 66.0,
@@ -1930,7 +1903,6 @@
                   "type": "object",
                   "title": "The SuggestedLowerPricePlusShipping schema",
                   "description": "An explanation about the purpose of this instance.",
-                  "default": {},
                   "examples": [
                     {
                       "Amount": 77.0,
@@ -2001,7 +1973,6 @@
                         "type": "object",
                         "title": "The first anyOf schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "ProductCategoryId": "1243",
@@ -2068,7 +2039,6 @@
                         "type": "object",
                         "title": "The first anyOf schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "Condition": "new",
@@ -2124,7 +2094,6 @@
                   "type": "object",
                   "title": "The CompetitivePriceThreshold schema",
                   "description": "An explanation about the purpose of this instance.",
-                  "default": {},
                   "examples": [
                     {
                       "Amount": 22.0,
@@ -2217,7 +2186,6 @@
                     "type": "object",
                     "title": "The first anyOf schema",
                     "description": "An explanation about the purpose of this instance.",
-                    "default": {},
                     "examples": [
                       {
                         "SellerId": "111",
@@ -2301,7 +2269,6 @@
                         "type": "object",
                         "title": "The SellerFeedbackRating schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "FeedbackCount": 9,
@@ -2341,7 +2308,6 @@
                         "type": "object",
                         "title": "The ShippingTime schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "MinimumHours": 10,
@@ -2405,7 +2371,6 @@
                         "type": "object",
                         "title": "The ListingPrice schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "Amount": 23.0,
@@ -2445,7 +2410,6 @@
                         "type": "object",
                         "title": "The Points schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "PointsNumber": 33333
@@ -2473,7 +2437,6 @@
                         "type": "object",
                         "title": "The Shipping schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "Amount": 110.0,
@@ -2513,7 +2476,6 @@
                         "type": "object",
                         "title": "The ShipsFrom schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "Country": "USA",
@@ -2563,7 +2525,6 @@
                         "type": "object",
                         "title": "The PrimeInformation schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "IsOfferPrime": true,

--- a/schemas/notifications/BrandedItemContentChangeNotification.json
+++ b/schemas/notifications/BrandedItemContentChangeNotification.json
@@ -4,7 +4,6 @@
   "type": "object",
   "title": "The root schema",
   "description": "The root schema comprises the entire JSON document.",
-  "default": {},
   "examples": [
     {
       "NotificationVersion": "1.0",
@@ -93,7 +92,6 @@
       "type": "object",
       "title": "The Payload schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "MarketplaceId": "ATVPDKIKX0DER",
@@ -185,7 +183,6 @@
       "type": "object",
       "title": "The NotificationMetadata schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "ApplicationId": "amzn1.sellerapps.app.f1234566-aaec-55a6-b123-bcb752069ec5",

--- a/schemas/notifications/FBAInventoryAvailabilityChangeNotification.json
+++ b/schemas/notifications/FBAInventoryAvailabilityChangeNotification.json
@@ -4,7 +4,13 @@
   "type": "object",
   "title": "The root schema",
   "description": "The root schema comprises the entire JSON document.",
-  "default": {},
+  "required": [
+    "NotificationVersion",
+    "NotificationType",
+    "PayloadVersion",
+    "EventTime",
+    "Payload"
+  ],
   "properties": {
     "NotificationVersion": {
       "$id": "#/properties/NotificationVersion",

--- a/schemas/notifications/FeePromotionNotification.json
+++ b/schemas/notifications/FeePromotionNotification.json
@@ -4,7 +4,6 @@
   "type": "object",
   "title": "The root schema",
   "description": "The root schema comprises the entire JSON document.",
-  "default": {},
   "examples": [
     {
       "NotificationVersion": "1.0",
@@ -395,7 +394,6 @@
       "type": "object",
       "title": "The NotificationMetadata schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "ApplicationId": "app-id-d0e9e693-c3ad-4373-979f-ed4ec98dd746",
@@ -459,7 +457,6 @@
       "type": "object",
       "title": "The Payload schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "FeePromotionNotification": {
@@ -793,7 +790,6 @@
           "type": "object",
           "title": "The FeePromotionNotification schema",
           "description": "An explanation about the purpose of this instance.",
-          "default": {},
           "examples": [
             {
               "MerchantId": "AJH434853485",
@@ -1171,7 +1167,6 @@
               "type": "object",
               "title": "The PromotionActiveTimeRange schema",
               "description": "An explanation about the purpose of this instance.",
-              "default": {},
               "examples": [
                 {
                   "EffectiveFromDate": "2020-07-13T19:42:04.284Z",
@@ -1251,7 +1246,6 @@
                     "type": "object",
                     "title": "The first anyOf schema",
                     "description": "An explanation about the purpose of this instance.",
-                    "default": {},
                     "examples": [
                       {
                         "IdentifierType": "identifierType",
@@ -1309,7 +1303,6 @@
                               "type": "object",
                               "title": "The first anyOf schema",
                               "description": "An explanation about the purpose of this instance.",
-                              "default": {},
                               "examples": [
                                 {
                                   "IdentifierValueId": "identifierValueId1",
@@ -1652,7 +1645,6 @@
                     "type": "object",
                     "title": "The first anyOf schema",
                     "description": "An explanation about the purpose of this instance.",
-                    "default": {},
                     "examples": [
                       {
                         "FeeType": "FeeType",
@@ -1839,7 +1831,6 @@
                         "type": "object",
                         "title": "The PriceThreshold schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "Amount": 60,
@@ -1879,7 +1870,6 @@
                         "type": "object",
                         "title": "The FeeDiscountMonetaryAmount schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "Amount": 70,
@@ -1919,7 +1909,6 @@
                         "type": "object",
                         "title": "The FeesEstimate schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "TimeOfFeesEstimated": "2020-07-13T19:42:04.284Z",
@@ -2070,7 +2059,6 @@
                             "type": "object",
                             "title": "The TotalFeesEstimate schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
                             "examples": [
                               {
                                 "Amount": 90,
@@ -2242,7 +2230,6 @@
                                   "type": "object",
                                   "title": "The first anyOf schema",
                                   "description": "An explanation about the purpose of this instance.",
-                                  "default": {},
                                   "examples": [
                                     {
                                       "FeeType": "feeType",
@@ -2328,7 +2315,6 @@
                                       "type": "object",
                                       "title": "The FeeAmount schema",
                                       "description": "An explanation about the purpose of this instance.",
-                                      "default": {},
                                       "examples": [
                                         {
                                           "Amount": 10,
@@ -2368,7 +2354,6 @@
                                       "type": "object",
                                       "title": "The TaxAmount schema",
                                       "description": "An explanation about the purpose of this instance.",
-                                      "default": {},
                                       "examples": [
                                         {
                                           "Amount": 20,
@@ -2408,7 +2393,6 @@
                                       "type": "object",
                                       "title": "The FeePromotion schema",
                                       "description": "An explanation about the purpose of this instance.",
-                                      "default": {},
                                       "examples": [
                                         {
                                           "Amount": 30,
@@ -2448,7 +2432,6 @@
                                       "type": "object",
                                       "title": "The FinalFee schema",
                                       "description": "An explanation about the purpose of this instance.",
-                                      "default": {},
                                       "examples": [
                                         {
                                           "Amount": 40,
@@ -2540,7 +2523,6 @@
                                             "type": "object",
                                             "title": "The first anyOf schema",
                                             "description": "An explanation about the purpose of this instance.",
-                                            "default": {},
                                             "examples": [
                                               {
                                                 "FeeType": "feeType",
@@ -2585,7 +2567,6 @@
                                                 "type": "object",
                                                 "title": "The FeeAmount schema",
                                                 "description": "An explanation about the purpose of this instance.",
-                                                "default": {},
                                                 "examples": [
                                                   {
                                                     "Amount": 10,
@@ -2625,7 +2606,6 @@
                                                 "type": "object",
                                                 "title": "The TaxAmount schema",
                                                 "description": "An explanation about the purpose of this instance.",
-                                                "default": {},
                                                 "examples": [
                                                   {
                                                     "Amount": 20,
@@ -2665,7 +2645,6 @@
                                                 "type": "object",
                                                 "title": "The FeePromotion schema",
                                                 "description": "An explanation about the purpose of this instance.",
-                                                "default": {},
                                                 "examples": [
                                                   {
                                                     "Amount": 30,
@@ -2705,7 +2684,6 @@
                                                 "type": "object",
                                                 "title": "The FinalFee schema",
                                                 "description": "An explanation about the purpose of this instance.",
-                                                "default": {},
                                                 "examples": [
                                                   {
                                                     "Amount": 40,

--- a/schemas/notifications/FulfillmentOrderStatusNotification.json
+++ b/schemas/notifications/FulfillmentOrderStatusNotification.json
@@ -4,7 +4,6 @@
   "type": "object",
   "title": "The root schema",
   "description": "The root schema comprises the entire JSON document.",
-  "default": {},
   "examples": [
     {
       "NotificationVersion": "1.0",
@@ -114,7 +113,6 @@
       "type": "object",
       "title": "The Payload schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "FulfillmentOrderStatusNotification": {
@@ -167,7 +165,6 @@
           "type": "object",
           "title": "The FulfillmentOrderStatusNotification schema",
           "description": "An explanation about the purpose of this instance.",
-          "default": {},
           "examples": [
             {
               "SellerId": "A3TH9S8BH6GOGM",
@@ -274,7 +271,6 @@
               "type": "object",
               "title": "The FulfillmentShipment schema",
               "description": "An explanation about the purpose of this instance.",
-              "default": {},
               "examples": [
                 {
                   "FulfillmentShipmentStatus": "PROCESSED",
@@ -368,7 +364,6 @@
                       "type": "object",
                       "title": "The info schema",
                       "description": "An explanation about the purpose of this instance.",
-                      "default": {},
                       "examples": [
                         {
                           "PackageNumber": 1,
@@ -425,7 +420,6 @@
                         "type": "object",
                         "title": "The first anyOf schema",
                         "description": "An explanation about the purpose of this instance.",
-                        "default": {},
                         "examples": [
                           {
                             "PackageNumber": 1,
@@ -483,7 +477,6 @@
               "type": "object",
               "title": "The FulfillmentReturnItem schema",
               "description": "An explanation about the purpose of this instance.",
-              "default": {},
               "examples": [
                 {
                   "ReceivedDateTime": "2020-07-13T19:42:04.284Z",
@@ -541,7 +534,6 @@
       "type": "object",
       "title": "The NotificationMetadata schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "ApplicationId": "app-id-d0e9e693-c3ad-4373-979f-ed4ec98dd746",

--- a/schemas/notifications/ItemProductTypeChangeNotification.json
+++ b/schemas/notifications/ItemProductTypeChangeNotification.json
@@ -4,7 +4,6 @@
   "type": "object",
   "title": "The root schema",
   "description": "The root schema comprises the entire JSON document.",
-  "default": {},
   "examples": [
     {
       "NotificationVersion": "1.0",
@@ -79,7 +78,6 @@
       "type": "object",
       "title": "The Payload schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "MarketplaceId": "ATVPDKIKX0DER",
@@ -143,7 +141,6 @@
       "type": "object",
       "title": "The NotificationMetadata schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "ApplicationId": "amzn1.sellerapps.app.f1234566-aaec-55a6-b123-bcb752069ec5",

--- a/schemas/notifications/MfnOrderStatusChangeNotification.json
+++ b/schemas/notifications/MfnOrderStatusChangeNotification.json
@@ -4,7 +4,6 @@
   "type": "object",
   "title": "The root schema",
   "description": "The root schema comprises the entire JSON document.",
-  "default": {},
   "examples": [
     {
       "NotificationVersion": "1.0",
@@ -87,7 +86,6 @@
       "type": "object",
       "title": "The Payload schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "MFNOrderStatusChangeNotification": {
@@ -113,7 +111,6 @@
           "type": "object",
           "title": "The MFNOrderStatusChangeNotification schema",
           "description": "An explanation about the purpose of this instance.",
-          "default": {},
           "examples": [
             {
               "SellerId": "AXXXXXXXXXXXXX",
@@ -251,7 +248,6 @@
       "type": "object",
       "title": "The NotificationMetadata schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "ApplicationId": "app-id-d0e9e693-c3ad-4373-979f-ed4ec98dd746",

--- a/schemas/notifications/OrderStatusChangeNotification.json
+++ b/schemas/notifications/OrderStatusChangeNotification.json
@@ -4,7 +4,6 @@
   "type": "object",
   "title": "The root schema",
   "description": "The root schema comprises the entire JSON document.",
-  "default": {},
   "examples": [
     {
       "NotificationVersion": "1.0",
@@ -88,7 +87,6 @@
       "type": "object",
       "title": "The Payload schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "OrderStatusChangeNotification": {
@@ -115,7 +113,6 @@
           "type": "object",
           "title": "The OrderStatusChangeNotification schema",
           "description": "An explanation about the purpose of this instance.",
-          "default": {},
           "examples": [
             {
               "SellerId": "AXXXXXXXXXXXXX",
@@ -264,7 +261,6 @@
       "type": "object",
       "title": "The NotificationMetadata schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "ApplicationId": "app-id-d0e9e693-c3ad-4373-979f-ed4ec98dd746",

--- a/schemas/notifications/ProductTypeDefinitionsChangeNotification.json
+++ b/schemas/notifications/ProductTypeDefinitionsChangeNotification.json
@@ -4,7 +4,6 @@
   "type": "object",
   "title": "The root schema",
   "description": "The root schema comprises the entire JSON document.",
-  "default": {},
   "examples": [
     {
       "NotificationVersion":"1.0",
@@ -82,7 +81,6 @@
       "type": "object",
       "title": "The Payload schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "AccountId": "AXXXXXXXXXXX",
@@ -154,7 +152,6 @@
       "type": "object",
       "title": "The NotificationMetadata schema",
       "description": "An explanation about the purpose of this instance.",
-      "default": {},
       "examples": [
         {
           "ApplicationId": "amzn1.sellerapps.app.f1234566-aaec-55a6-b123-bcb752069ec5",


### PR DESCRIPTION
There are many schemas that include `"default": {}` for keys of type object, that include required keys, making that default value invalid.

Removing these invalid defaults fixes the schema conversion using tools like `go-jsonschema` [1], as now it understands the object cannot be empty.

[1] https://github.com/omissis/go-jsonschema

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
