### PR TITLE
#4478: Correct source directories for Java auth client.

### DIFF
--- a/clients/sellingpartner-api-aa-java/pom.xml
+++ b/clients/sellingpartner-api-aa-java/pom.xml
@@ -38,8 +38,8 @@
                 </configuration>
             </plugin>
         </plugins>
-        <sourceDirectory>src/main/java</sourceDirectory>
-        <testSourceDirectory>src/test/java</testSourceDirectory>
+        <sourceDirectory>src</sourceDirectory>
+        <testSourceDirectory>tst</testSourceDirectory>
         <directory>target</directory>
         <finalName>${project.artifactId}-${project.version}</finalName>
     </build>


### PR DESCRIPTION
Closes #4478 

Updates the `sourceDirectory` and `testSourceDirectory` values of `clients/sellingpartner-api-aa-java/pom.xml` to point to the correct directories.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
