### PR TITLE
Update finances_2024-06-19.json: add FINANCIAL_EVENT_GROUP_ID to relatedIdentifierName enum

### DIFF
--- a/models/finances-api-model/finances_2024-06-19.json
+++ b/models/finances-api-model/finances_2024-06-19.json
@@ -464,7 +464,8 @@
             "INVOICE_ID",
             "DISBURSEMENT_ID",
             "TRANSFER_ID",
-            "DEFERRED_TRANSACTION_ID"
+            "DEFERRED_TRANSACTION_ID",
+            "FINANCIAL_EVENT_GROUP_ID"
           ],
           "x-docgen-enum-table-extension": [
             {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

When requesting transactions, some have the relatedIdentifierName: "FINANCIAL_EVENT_GROUP_ID".