### PR TITLE
Fix setDebugging in swagger-cogen java template

### DIFF
--- a/clients/sellingpartner-api-aa-java/resources/swagger-codegen/templates/ApiClient.mustache
+++ b/clients/sellingpartner-api-aa-java/resources/swagger-codegen/templates/ApiClient.mustache
@@ -342,9 +342,11 @@ public class ApiClient {
             if (debugging) {
                 loggingInterceptor = new HttpLoggingInterceptor();
                 loggingInterceptor.setLevel(Level.BODY);
-                httpClient.interceptors().add(loggingInterceptor);
+                httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
             } else {
-                httpClient.interceptors().remove(loggingInterceptor);
+                OkHttpClient.Builder builder = httpClient.newBuilder();
+                builder.interceptors().remove(loggingInterceptor);
+                httpClient = builder.build();
                 loggingInterceptor = null;
             }
         }


### PR DESCRIPTION
was trying to insert an interceptor into an immutable collection : The Interceptor list in OKHttpClient is immutable once the object is created. To workaround this limitation we have to use newBuilder() that keeps all the existing parameters and allows to add or remove interceptors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
